### PR TITLE
Add page numbers to generated PDFs

### DIFF
--- a/frontend/scss/print.scss
+++ b/frontend/scss/print.scss
@@ -11,6 +11,13 @@ html.s-print body {
   width: auto;
 }
 
+@page {
+  @bottom-right {
+    content: counter(page);
+    font-size: 10pt;
+  }
+}
+
 .s-print #a17 {
   * {
     background: transparent;


### PR DESCRIPTION
This change adds a page number to the bottom right of the generated PDFs. I set `font-size: 10pt` because by default it was the same size as the rest of the text and looked a little odd to me. I consulted with Josh, and he said that we don't need to precede the page number with "Page".