### PR TITLE
Remove link option from list item wysiwyg

### DIFF
--- a/resources/views/admin/repeaters/list_item.blade.php
+++ b/resources/views/admin/repeaters/list_item.blade.php
@@ -26,7 +26,7 @@
     'label' => 'Description',
     'rows' => 4,
     'toolbarOptions' => [
-        'italic', 'link'
+        'italic',
     ],
 ])
 


### PR DESCRIPTION
Removing this option prevents users from being able to include html links in the list item's description, which causes the list item to be rendered oddly when the list item already has an associated link.