### PR TITLE
Print images redux

### DIFF
--- a/frontend/scss/print.scss
+++ b/frontend/scss/print.scss
@@ -261,6 +261,10 @@ html.s-print body {
     display: block;
   }
 
+  .o-gallery--slider__controls {
+    display: none;
+  }
+
   .o-accordion__panel {
     height: auto;
   }

--- a/frontend/scss/print.scss
+++ b/frontend/scss/print.scss
@@ -175,6 +175,14 @@ html.s-print body {
   }
 
   .o-blocks {
+    & > h2 {
+      font-size: 2em;
+      margin-top: 2em;
+    }
+    & > h3 {
+      font-size: 1.5em;
+      margin-top: 1.5em;
+    }
     & > h5,
     & > p,
     & > ul,

--- a/frontend/scss/print.scss
+++ b/frontend/scss/print.scss
@@ -298,21 +298,13 @@ html.s-print body {
   }
 
   .m-media.m-media--gallery,
-  .m-media.m-media--l {
+  .m-media.m-media--l,
+  .m-media.m-media--s {
     & .m-media__img {
       width: 50%;
     }
     & figcaption {
       max-width: 50%;
-    }
-  }
-
-  .m-media.m-media--s {
-    & .m-media__img {
-      width: 25%;
-    }
-    & figcaption {
-      max-width: 75%;
     }
   }
 
@@ -332,6 +324,7 @@ html.s-print body {
     height: auto;
     margin: 0;
     max-height: 50vw;
+    max-width: 50vw;
     width: 100%;
   }
 


### PR DESCRIPTION
These changes to the print styling include:
- adjusting small media blocks to look like large media blocks
- increasing the size and padding of the second and third level headers 
- hiding the gallery slider controls