### PR TITLE
Remove schema from APP_URL

### DIFF
--- a/.env.testing
+++ b/.env.testing
@@ -3,7 +3,7 @@ APP_ENV=testing
 APP_KEY=base64:nkScfqkJ+t4c4JMZOgO4hEK6gy0rOEF9f71FuL6AuzI=
 APP_DEBUG=true
 APP_LOG_LEVEL=debug
-APP_URL=http://localhost
+APP_URL=localhost
 
 DB_CONNECTION='pgsql'
 DB_HOST='127.0.0.1'

--- a/tests/Feature/ArtworkTest.php
+++ b/tests/Feature/ArtworkTest.php
@@ -28,8 +28,8 @@ class ArtworkTest extends BaseTestCase
         $artwork = Artwork::factory()->make();
         $this->addMockApiResponses($this->mockApiModelReponse($artwork));
 
-        $response = $this->get("/artworks/{$artwork->id}");
-        $response->assertRedirect("/artworks/{$artwork->id}/{$artwork->titleSlug}");
+        $response = $this->get(route('artworks.show', ['id' => $artwork->id]));
+        $response->assertRedirect(route('artworks.show', ['id' => $artwork->id, 'slug' => $artwork->titleSlug]));
     }
 
     public function test_artwork_show_displays_edition()
@@ -42,7 +42,7 @@ class ArtworkTest extends BaseTestCase
             $this->mockApiSearchResponse(), // Search for educational resources
         ]);
 
-        $response = $this->get("/artworks/{$artwork->id}/{$artwork->titleSlug}");
+        $response = $this->get(route('artworks.show', ['id' => $artwork->id, 'slug' => $artwork->titleSlug]));
         $response->assertStatus(200);
         $response->assertSee('Title');
         $response->assertSee($artwork->title);
@@ -61,7 +61,7 @@ class ArtworkTest extends BaseTestCase
             $this->mockApiSearchResponse(), // Search for educational resources
         ]);
 
-        $response = $this->get("/artworks/{$artwork->id}/{$artwork->titleSlug}");
+        $response = $this->get(route('artworks.show', ['id' => $artwork->id, 'slug' => $artwork->titleSlug]));
         $response->assertSee('Discover More');
         $this->assertApiRequestReceived('GET', "/api/v1/artworks/{$artwork->id}");
         $this->assertApiRequestReceived('POST', '/api/v1/msearch');

--- a/tests/Feature/EventTest.php
+++ b/tests/Feature/EventTest.php
@@ -13,7 +13,7 @@ class EventTest extends BaseTestCase
 
     public function test_event_page_displays_events()
     {
-        $response = $this->get('/events');
+        $response = $this->get(route('events'));
         $response->assertSee(Event::get()->pluck('title_display')->all());
     }
 
@@ -26,7 +26,7 @@ class EventTest extends BaseTestCase
             $event->save();
         });
 
-        $response = $this->get("/events?program=$eventProgram->id");
+        $response = $this->get(route('events', ['program' => $eventProgram->id]));
 
         $response->assertStatus(200);
 

--- a/tests/Feature/HomePageTest.php
+++ b/tests/Feature/HomePageTest.php
@@ -15,14 +15,14 @@ class HomePageTest extends BaseTestCase
 
     public function test_home_page_loads()
     {
-        $response = $this->get('/');
+        $response = $this->get(route('home'));
         $response->assertStatus(200);
     }
 
     public function test_visit_page_links_appear_on_home_page()
     {
         $appUrl = config('APP_URL');
-        $response = $this->get('/');
+        $response = $this->get(route('home'));
         $response->assertSee('Hours and admission fees');
         $response->assertSee("href=\"{$appUrl}/visit#hours\"", false);
         $response->assertSee('Directions and parking');
@@ -31,7 +31,7 @@ class HomePageTest extends BaseTestCase
 
     public function test_events_section_appears_on_home_page()
     {
-        $response = $this->get('/');
+        $response = $this->get(route('home'));
         $response->assertSee('Events');
         $response->assertSee('See upcoming events');
     }
@@ -47,14 +47,14 @@ class HomePageTest extends BaseTestCase
         $this->assertDatabaseCount('events', 5);
 
         $events = Event::get();
-        $response = $this->get('/');
+        $response = $this->get(route('home'));
         $response->assertSee($events->take(4)->pluck('title_display')->all(), 'Home page displays first four events');
         $response->assertDontSee($events->last()->title_display, 'Home page displays only the first four events');
     }
 
     public function test_events_times_appear_on_home_page()
     {
-        $response = $this->get('/');
+        $response = $this->get(route('home'));
         $forcedFormattedDates = Event::whereNotNull('forced_date')->get()->pluck('forced_date')->all();
         $response->assertSee($forcedFormattedDates, 'Home page displays forced formatted dates as they are');
 

--- a/tests/Feature/RobotsTxtTest.php
+++ b/tests/Feature/RobotsTxtTest.php
@@ -9,14 +9,14 @@ class RobotsTxtTest extends BaseTestCase
 {
     public function test_robots_txt_loads()
     {
-        $response = $this->get('/robots.txt');
+        $response = $this->get(route('robots-txt'));
         $response->assertStatus(200);
     }
 
     public function test_blocks_all_traffic_when_not_production()
     {
         Config::set('app.env', 'testing');
-        $response = $this->get('/robots.txt');
+        $response = $this->get(route('robots-txt'));
         $this->assertEquals("User-agent: *\nDisallow: /", $response->getContent());
     }
 
@@ -25,7 +25,7 @@ class RobotsTxtTest extends BaseTestCase
         Config::set('app.env', 'production');
         Config::set('app.debug', false);
         Config::set('app.url', 'www.example.com');
-        $response = $this->get('/robots.txt');
+        $response = $this->get(route('robots-txt'));
         $this->assertEquals("User-agent: *\nDisallow: /", $response->getContent());
     }
 
@@ -34,7 +34,7 @@ class RobotsTxtTest extends BaseTestCase
         Config::set('app.env', 'production');
         Config::set('app.debug', false);
         Config::set('app.url', 'localhost');
-        $response = $this->get('/robots.txt');
+        $response = $this->get(route('robots-txt'));
         $this->assertNotEquals("User-agent: *\nDisallow: /", $response->getContent());
     }
 }

--- a/tests/Feature/VisitPageTest.php
+++ b/tests/Feature/VisitPageTest.php
@@ -18,7 +18,7 @@ class VisitPageTest extends BaseTestCase
 
     public function test_visiting_hours_are_displayed()
     {
-        $response = $this->get('/visit');
+        $response = $this->get(route('visit'));
         $response->assertSee(
             'The Art Institute reopens on July 30, and we&#8217;re so happy to welcome you back to our galleries. Please see below for new hours—including member-only hours—and updated safety policies.',
             false
@@ -29,7 +29,7 @@ class VisitPageTest extends BaseTestCase
 
     public function test_admission_description_is_displayed()
     {
-        $response = $this->get('/visit');
+        $response = $this->get(route('visit'));
         $response->assertSee(
             'The Art Institute of Chicago provides free access to children under 14, Chicago teens under 18, Link and WIC cardholders, and Illinois educators every day, and to Illinois residents on certain days throughout the year.'
         );
@@ -37,7 +37,7 @@ class VisitPageTest extends BaseTestCase
 
     public function test_accessibility_link_is_displayed()
     {
-        $response = $this->get('/visit');
+        $response = $this->get(route('visit'));
         $response->assertSee(
             'The Art Institute of Chicago welcomes all visitors and is committed to making its services accessible to everyone. We offer a range of resources for both adults and children with disabilities.'
         );
@@ -47,7 +47,7 @@ class VisitPageTest extends BaseTestCase
 
     public function test_family_pages_titles_are_displayed_in_order()
     {
-        $response = $this->get('/visit');
+        $response = $this->get(route('visit'));
         $response->assertSeeInOrder([
             'Art Institute Mobile App',
             'What to See in an Hour',
@@ -57,7 +57,7 @@ class VisitPageTest extends BaseTestCase
 
     public function test_mobile_app_family_page_link_is_displayed()
     {
-        $response = $this->get('/visit');
+        $response = $this->get(route('visit'));
         $response->assertSee(
             'The Art Institute&#8217;s free app offers the stories behind the art through conversations with artists, experts, and community members. Download it via the App Store or Google Play.',
             false
@@ -68,7 +68,7 @@ class VisitPageTest extends BaseTestCase
 
     public function test_highlights_family_page_link_is_displayed()
     {
-        $response = $this->get('/visit');
+        $response = $this->get(route('visit'));
         $response->assertSee('Short on time? Check out this must-see guide to the collection.');
         $response->assertSee('More custom tours');
         $response->assertSee("href=\"{$this->appUrl}/highlights\"", false);
@@ -76,7 +76,7 @@ class VisitPageTest extends BaseTestCase
 
     public function test_visit_virtually_family_page_link_is_displayed()
     {
-        $response = $this->get('/visit');
+        $response = $this->get(route('visit'));
         $response->assertSee('Even from afar, there&#8217;s a host of ways to connect to our collection of art from around the world&mdash;whether you&#8217;re seeking inspiration, community, or a little adventure.', false);
         $response->assertSee('Learn more');
         $response->assertSee("href=\"{$this->appUrl}/visit-us-virtually\"", false);
@@ -84,7 +84,7 @@ class VisitPageTest extends BaseTestCase
 
     public function test_what_to_expect_items_are_displayed_in_order()
     {
-        $response = $this->get('/visit');
+        $response = $this->get(route('visit'));
         $response->assertSeeInOrder([
             'Face coverings will be required for your entire museum visit.',
             'Maintain a physical distance of six-feet from staff and visitors.',
@@ -97,5 +97,4 @@ class VisitPageTest extends BaseTestCase
             'Special exhibitions may use timed queueing systems. Check in at exhibition entrances to reserve your spot in line.',
         ]);
     }
-//
 }


### PR DESCRIPTION
The fact that the testing `APP_URL` contained the schema but the dev/prod one did not was causing me headaches in some other tests I was writing for PDF generation. This change removes the schema and then updates the tests to account for it.