### PR TITLE
Add error handling and cleanup to PDF generation

### DIFF
--- a/app/Console/Commands/GeneratePdfs.php
+++ b/app/Console/Commands/GeneratePdfs.php
@@ -12,7 +12,7 @@ use Prince\Prince;
 
 class GeneratePdfs extends Command
 {
-    public const STORAGE_PATH = '/pdf/static/';
+    public const BUCKET_PATH = '/pdf/static/';
 
     /**
      * The name and signature of the console command.
@@ -64,37 +64,18 @@ class GeneratePdfs extends Command
 
     protected function generatePdf($model, $route = null)
     {
-        if (empty($route)) {
-            $route = self::route($model);
-        }
-
+        $route = empty($route) ? self::route($model) : $route;
         if (empty($route)) {
             return false;
         }
-
-        $path = null;
-
-        if (get_class($model) == DigitalPublicationSection::class) {
-            $path = route($route, [
-                'pubId' => $model->digitalPublication->id,
-                'pubSlug' => $model->digitalPublication->getSlug(),
-                'id' => $model->id,
-                'slug' => $model->getSlug(),
-            ], false);
-        } else {
-            $path = route($route, [
-                'id' => $model->id,
-                'slug' => $model->getSlug(),
-            ], false);
-        }
-
         $baseUrl = config('aic.protocol') . '://' . config('app.url');
-        $fullUrl = $baseUrl . $path;
+        $fullUrl = $baseUrl . $this->path($model, $route);
 
         // Now, produce the PDF
         $prince = new Prince(config('aic.prince_command'));
         $prince->setBaseURL($baseUrl);
         $prince->setMedia('print');
+        $prince->setFailMissingResources(true);
 
         if (config('app.debug') || config('aic.pdf_debug')) {
             $prince->setVerbose(true);
@@ -103,36 +84,67 @@ class GeneratePdfs extends Command
 
         set_time_limit(0);
         $html = Http::get($fullUrl, ['print' => true])->body();
-
-        $pdfFileName = self::pdfFileName($model);
-        $pdfPath = storage_path('app/' . $pdfFileName);
-        $prince->convertStringToFile($html, $pdfPath);
-
-        if (config('aic.pdf_s3_enabled')) {
-            // Stream the file to S3; be sure to set `AWS_BUCKET` in `.env` and otherwise configure credentials
-            Storage::disk('pdf_s3')->putFileAs(self::STORAGE_PATH, new File($pdfPath), $pdfFileName, 'public');
+        $fileName = self::fileName($model);
+        $class = class_basename($model);
+        if ($prince->convertStringToFile($html, self::localPath($fileName))) {
+            $this->storePdf($fileName);
+        } else {
+            throw new \Exception("Prince was unable to generate a PDF for {$class} with ID {$model->id}");
         }
 
-        if ($model->pdf_download_path != self::pdfDownloadPath($pdfFileName)) {
-            $model->pdf_download_path = self::pdfDownloadPath($pdfFileName);
+        $model->pdf_download_path = self::downloadPath($fileName);
+        if ($model->isDirty('pdf_download_path')) {
             $model->save();
         }
-        $class = class_basename($model);
+
         $this->info("Generated PDF for {$class} with ID {$model->id}");
     }
 
-    public static function pdfFileName(AbstractModel $model): string
+    protected function path($model, $route): string
+    {
+        return route($route, [
+            'pubId' => $model->digitalPublication->id,
+            'pubSlug' => $model->digitalPublication->getSlug(),
+            'id' => $model->id,
+            'slug' => $model->getSlug(),
+        ], false);
+    }
+
+    /**
+     * Stream the file to S3 then remove the local copy. Be sure to set
+     * `AWS_BUCKET` in `.env` and otherwise configure credentials.
+     */
+    protected function storePdf($fileName): void
+    {
+        if (config('aic.pdf_s3_enabled')) {
+            $localPath = self::localPath($fileName);
+            Storage::disk('pdf_s3')->putFileAs(
+                self::BUCKET_PATH,
+                new File($localPath),
+                $fileName,
+                'public'
+            );
+            unlink($localPath);
+        }
+    }
+
+    public static function fileName(AbstractModel $model): string
     {
         $route = self::route($model);
         return 'download-' . $route . '-' . $model->id . '.pdf';
     }
 
-    public static function pdfDownloadPath($pdfFileName): string
+    public static function localPath($fileName): string
     {
-        return self::STORAGE_PATH . $pdfFileName;
+        return storage_path('app/' . $fileName);
     }
 
-    public static function route($model): string
+    public static function downloadPath($fileName): string
+    {
+        return self::BUCKET_PATH . $fileName;
+    }
+
+    protected static function route($model): string
     {
         return array_search(get_class($model), self::$models);
     }

--- a/tests/Feature/GeneratePdfsTest.php
+++ b/tests/Feature/GeneratePdfsTest.php
@@ -44,13 +44,6 @@ class GeneratePdfsTest extends BaseTestCase
             ->expectsOutput("Generated PDF for DigitalPublicationSection with ID {$this->sections->first()->id}");
     }
 
-    public function test_errors_when_prince_binary_not_present()
-    {
-        $noPrinceCommand = '/dev/null';
-        Config::set('aic.prince_command', $noPrinceCommand);
-        $this->artisan('pdfs:generate')->assertFailed()->expectsOutput("Prince could not be found at $noPrinceCommand");
-    }
-
     public function test_pdf_download_path_updated()
     {
         $this->assertNull($this->sections->first()->pdf_download_path);
@@ -59,7 +52,7 @@ class GeneratePdfsTest extends BaseTestCase
             'id' => $this->sections->first()->id,
         ]);
         $this->sections->first()->refresh();
-        $downloadPath = GeneratePdfs::pdfDownloadPath(GeneratePdfs::pdfFileName($this->sections->first()));
+        $downloadPath = GeneratePdfs::downloadPath(GeneratePdfs::fileName($this->sections->first()));
         $this->assertEquals($downloadPath, $this->sections->first()->pdf_download_path);
     }
 
@@ -71,7 +64,10 @@ class GeneratePdfsTest extends BaseTestCase
             'model' => DigitalPublicationSection::class,
             'id' => $this->sections->first()->id,
         ]);
-        $downloadPath = GeneratePdfs::pdfDownloadPath(GeneratePdfs::pdfFileName($this->sections->first()));
+        $fileName = GeneratePdfs::fileName($this->sections->first());
+        $localPath = GeneratePdfs::localPath($fileName);
+        Storage::disk('local')->assertMissing($localPath);
+        $downloadPath = GeneratePdfs::downloadPath($fileName);
         Storage::disk('pdf_s3')->assertExists($downloadPath);
     }
 }

--- a/tests/Feature/PrinceTest.php
+++ b/tests/Feature/PrinceTest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Tests\Feature;
+
+use Aic\Hub\Foundation\Testing\FeatureTestCase as BaseTestCase;
+use App\Models\DigitalPublication;
+use App\Models\DigitalPublicationSection;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Http;
+
+class PrinceTest extends BaseTestCase
+{
+    protected Collection $sections;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->sections = DigitalPublicationSection::factory()
+            ->count(2)
+            ->published()
+            ->for(DigitalPublication::factory()->published())
+            ->create();
+    }
+
+    public function test_errors_when_prince_binary_not_present()
+    {
+        Http::fake();
+        $noPrinceCommand = '/dev/null';
+        Config::set('aic.prince_command', $noPrinceCommand);
+        $this->artisan('pdfs:generate')->assertFailed()->expectsOutput("Prince could not be found at $noPrinceCommand");
+    }
+
+    public function test_errors_when_prince_cannot_generate_pdf()
+    {
+        Http::fake(['*' => Http::response('<link rel="stylesheet" href="missing resource">')]);
+        $id = $this->sections->first()->id;
+        $this->artisan('pdfs:generate-one', [
+            'model' => DigitalPublicationSection::class,
+            'id' => $id,
+        ])
+            ->assertFailed()
+            ->expectsOutput("Prince was unable to generate a PDF for DigitalPublicationSection with ID {$id}");
+    }
+}


### PR DESCRIPTION
This fixes a bug where, if Prince was unable to generate a PDF, it would fail silently, then upload to S3 the previously generated PDF that was still hanging around.