### PR TITLE
Fix LPB routing and genericPage relationships [WEB-2596]

### DIFF
--- a/app/Http/Controllers/Admin/GenericPageController.php
+++ b/app/Http/Controllers/Admin/GenericPageController.php
@@ -97,6 +97,11 @@ class GenericPageController extends ModuleController
         ];
     }
 
+    protected function transformIndexItems($items)
+    {
+        return $items->toTree();
+    }
+
     protected function indexItemData($item)
     {
         return $item->children ? [

--- a/app/Http/Controllers/Admin/GenericPageController.php
+++ b/app/Http/Controllers/Admin/GenericPageController.php
@@ -100,10 +100,9 @@ class GenericPageController extends ModuleController
     protected function transformIndexItems($items)
     {
         // If we're in the browser, don't transform the items
-        if (str_contains($items->path(), 'browser')) {
+        if (property_exists($items, 'path')) {
             return $items;
         }
-
         return $items->toTree();
     }
 

--- a/app/Http/Controllers/Admin/GenericPageController.php
+++ b/app/Http/Controllers/Admin/GenericPageController.php
@@ -99,6 +99,11 @@ class GenericPageController extends ModuleController
 
     protected function transformIndexItems($items)
     {
+        // If we're in the browser, don't transform the items
+        if (str_contains($items->path(), 'browser')) {
+            return $items;
+        }
+
         return $items->toTree();
     }
 

--- a/app/Http/Controllers/LandingPagesController.php
+++ b/app/Http/Controllers/LandingPagesController.php
@@ -42,6 +42,11 @@ class LandingPagesController extends FrontController
             return $canonicalRedirect;
         }
 
+        if ($item->is_unlisted) {
+            $this->seo->nofollow = true;
+            $this->seo->noindex = true;
+        }
+
         // Home
         $mainHomeFeatures = $item->mainHomeFeatures()->published()->limit(1)->get();
         $secondaryHomeFeatures = $item->secondaryHomeFeatures()->published()->limit(2)->get();

--- a/app/Http/Controllers/LandingPagesController.php
+++ b/app/Http/Controllers/LandingPagesController.php
@@ -42,7 +42,7 @@ class LandingPagesController extends FrontController
             return $canonicalRedirect;
         }
 
-        if ($item->is_unlisted) {
+        if (!$item->is_published) {
             $this->seo->nofollow = true;
             $this->seo->noindex = true;
         }

--- a/app/Http/Middleware/ResolvePageRedirect.php
+++ b/app/Http/Middleware/ResolvePageRedirect.php
@@ -25,7 +25,9 @@ class ResolvePageRedirect
         }
 
         $landingPageModel = LandingPage::published()->join('landing_page_slugs', function ($join) use ($slug) {
-            $join->on('landing_page_slugs.landing_page_id', 'landing_pages.id')->where('landing_page_slugs.slug', $slug);
+            $join->on('landing_page_slugs.landing_page_id', 'landing_pages.id')
+                 ->where('landing_page_slugs.slug', $slug)
+                 ->where('landing_page_slugs.active', true);
         })->first();
 
 

--- a/app/Http/Middleware/ResolvePageRedirect.php
+++ b/app/Http/Middleware/ResolvePageRedirect.php
@@ -30,7 +30,6 @@ class ResolvePageRedirect
                  ->where('landing_page_slugs.active', true);
         })->first();
 
-
         if ($landingPageModel) {
             // To satisfy the HTTP protocol we need to generate a response from the controller as if we were going there
 

--- a/app/Http/Middleware/ResolvePageRedirect.php
+++ b/app/Http/Middleware/ResolvePageRedirect.php
@@ -50,26 +50,6 @@ class ResolvePageRedirect
             return $response;
         }
 
-        $genericPageModel = GenericPage::published()->join('generic_page_slugs', function ($join) use ($slug) {
-            $join->on('generic_page_slugs.generic_page_id', 'generic_pages.id')->where('generic_page_slugs.slug', $slug);
-        })->first();
-
-
-        if ($genericPageModel) {
-            $newRequest = Request::create(
-                route('genericPage.show', ['id' => $genericPageModel->id, 'slug' => $slug]),
-                'GET',
-                [],
-                $request->cookie(),
-                [],
-                $request->server()
-            );
-
-            $response = app()->handle($newRequest);
-
-            return $response;
-        }
-
         return $next($request);
     }
 }

--- a/app/Http/Middleware/ResolvePageRedirect.php
+++ b/app/Http/Middleware/ResolvePageRedirect.php
@@ -35,7 +35,7 @@ class ResolvePageRedirect
 
             // Create a new request here
             $newRequest = Request::create(
-                route('landingPages.show', ['id' => $landingPageModel->id, 'slug' => $slug]),
+                route('landingPages.show', ['id' => $landingPageModel->landing_page_id, 'slug' => $slug]),
                 'GET',
                 [],
                 $request->cookie(),


### PR DESCRIPTION
These changes fix the LPB routing and genericPage relationships that were broken from deleting the `transformIndexItems` method.