### PR TITLE
Feature: add position to exhibition api [API-384]

### DIFF
--- a/app/Http/Middleware/ResolvePageRedirect.php
+++ b/app/Http/Middleware/ResolvePageRedirect.php
@@ -17,7 +17,6 @@ class ResolvePageRedirect
      */
     public function handle(Request $request, Closure $next)
     {
-
         $slug = strtolower($request->path());
 
         if ($slug === "/") {

--- a/app/Models/Behaviors/HasRelated.php
+++ b/app/Models/Behaviors/HasRelated.php
@@ -32,7 +32,9 @@ trait HasRelated
         if ($item->{$prefix . '_type'} === 'exhibitions') {
             return;
         }
-
+        if (!$item->{$prefix}) {
+            return;
+        }
         return [
             'id' => $item->{$prefix . '_id'},
             'type' => $item->{$prefix . '_type'},

--- a/app/Models/Exhibition.php
+++ b/app/Models/Exhibition.php
@@ -29,6 +29,9 @@ class Exhibition extends AbstractModel
 
     protected $apiModel = 'App\Models\Api\Exhibition';
 
+    protected $presenter = 'App\Presenters\Admin\ExhibitionPresenter';
+    protected $presenterAdmin = 'App\Presenters\Admin\ExhibitionPresenter';
+
     protected $dispatchesEvents = [
         'saved' => \App\Events\UpdateExhibition::class,
         'deleted' => \App\Events\UpdateExhibition::class,
@@ -284,6 +287,14 @@ class Exhibition extends AbstractModel
                 'value' => function () {
                     // WEB-1822, WEB-1830: This causes errors when the API model isn't found, needs more work on several fronts
                     // return trim(html_entity_decode(strip_tags($this->getApiModelFilledCached()->present()->formattedDate()->render())));
+                },
+            ],
+            [
+                'name' => 'position',
+                'doc' => 'Position this exhibition has on the exhibition landing page',
+                'type' => 'integer',
+                'value' => function () {
+                    return $this->present()->position();
                 },
             ],
             [

--- a/app/Presenters/Admin/ExhibitionPresenter.php
+++ b/app/Presenters/Admin/ExhibitionPresenter.php
@@ -80,6 +80,11 @@ class ExhibitionPresenter extends BasePresenter
             return $item->datahub_id == $this->entity->datahub_id;
         });
 
+        // $featurePos represents the first two spots on the exhibition landing page
+        // $listingPos represents the remaining exhibitions listed on the landing page
+        // If the exhibition is the featured position, return its value
+        // If the exhibition is listed below the featured two, bump its index by two and return it
+        // Otherwise, the exhibition is not listed on the exhibition landing page. Return -1.
         return $featurePos !== false ? $featurePos : ($listingPos !== false ? $listingPos + 2 : -1);
     }
 

--- a/app/Presenters/Admin/ExhibitionPresenter.php
+++ b/app/Presenters/Admin/ExhibitionPresenter.php
@@ -4,6 +4,7 @@ namespace App\Presenters\Admin;
 
 use Carbon\Carbon;
 use App\Presenters\BasePresenter;
+use App\Models\Page;
 use Illuminate\Support\Str;
 
 class ExhibitionPresenter extends BasePresenter
@@ -65,6 +66,21 @@ class ExhibitionPresenter extends BasePresenter
 
                 break;
         }
+    }
+
+    public function position()
+    {
+        $page = Page::forType('Exhibitions and Events')->with('apiElements')->first();
+
+        $featurePos = $page->exhibitionsExhibitions->search(function ($item) {
+            return $item->datahub_id == $this->entity->datahub_id;
+        });
+
+        $listingPos = $page->exhibitionsCurrent->search(function ($item) {
+            return $item->datahub_id == $this->entity->datahub_id;
+        });
+
+        return $featurePos !== false ? $featurePos : ($listingPos !== false ? $listingPos+2 : -1);
     }
 
     public function exhibitionType()

--- a/app/Presenters/Admin/ExhibitionPresenter.php
+++ b/app/Presenters/Admin/ExhibitionPresenter.php
@@ -80,7 +80,7 @@ class ExhibitionPresenter extends BasePresenter
             return $item->datahub_id == $this->entity->datahub_id;
         });
 
-        return $featurePos !== false ? $featurePos : ($listingPos !== false ? $listingPos+2 : -1);
+        return $featurePos !== false ? $featurePos : ($listingPos !== false ? $listingPos + 2 : -1);
     }
 
     public function exhibitionType()

--- a/database/migrations/2023_08_08_111957_add_admission_tix_field_to_landing_pages.php
+++ b/database/migrations/2023_08_08_111957_add_admission_tix_field_to_landing_pages.php
@@ -11,8 +11,8 @@ class AddAdmissionTixFieldToLandingPages extends Migration
         Schema::table('landing_pages', function (Blueprint $table) {
             $table->string('visit_admission_members_link')->nullable();
             $table->string('visit_admission_members_label')->nullable();
-            $table->string('visit_admission_tix_link')->nullable(); 
-            $table->string('visit_admission_tix_label')->nullable();      
+            $table->string('visit_admission_tix_link')->nullable();
+            $table->string('visit_admission_tix_label')->nullable();
         });
     }
 
@@ -22,7 +22,7 @@ class AddAdmissionTixFieldToLandingPages extends Migration
             $table->dropColumn('visit_admission_members_link');
             $table->dropColumn('visit_admission_members_label');
             $table->dropColumn('visit_admission_tix_link');
-            $table->dropColumn('visit_admission_tix_label');  
+            $table->dropColumn('visit_admission_tix_label');
         });
     }
 }

--- a/resources/views/components/molecules/_m-title-bar.blade.php
+++ b/resources/views/components/molecules/_m-title-bar.blade.php
@@ -1,5 +1,6 @@
 <?php
 use Illuminate\Support\Str;
+
 ?>
 
 {{-- There are a few things happening here that may be worth refactoring at some point:


### PR DESCRIPTION
This PR adds a `position` field to the exhibition API output. It represents the position that the exhibition is on the current exhibitions page. If the exhibition is not listed on that page `position` will return `-1`.