### PR TITLE
Fix: hide admission tooltips [WEB-2658]

### DIFF
--- a/frontend/js/behaviors/core/showAdmissionTooltip.js
+++ b/frontend/js/behaviors/core/showAdmissionTooltip.js
@@ -1,6 +1,5 @@
 const showAdmissionTooltip = function(container) {
 
-    let infoOpen = false;
     let tooltipSized = false;
 
     let targetAttribute = container.getAttribute('data-tooltip-target');
@@ -19,7 +18,6 @@ const showAdmissionTooltip = function(container) {
     function hideTooltips() {
         const tooltips = document.querySelectorAll('.admission-info-button-info');
         tooltips.forEach(element => {
-            infoOpen = false;
             element.setAttribute('style', 'display: none');
             element.setAttribute('aria-expanded','false');
             element.setAttribute('aria-hidden','true');
@@ -29,7 +27,6 @@ const showAdmissionTooltip = function(container) {
 
     function showTooltip(targetTooltip) {
         if (targetTooltip) {
-            infoOpen = true;
             targetTooltip.setAttribute('aria-expanded','true');
             targetTooltip.setAttribute('aria-hidden','false');
             targetTooltip.setAttribute('style', 'display: block');

--- a/frontend/js/behaviors/core/showAdmissionTooltip.js
+++ b/frontend/js/behaviors/core/showAdmissionTooltip.js
@@ -40,9 +40,9 @@ const showAdmissionTooltip = function(container) {
     function sizeToolTips() {
         if (!tooltipSized){
             tooltipSized = true;
-        
+
             const posTooltips = document.querySelectorAll('.admission-info-button-info');
-            
+
             posTooltips.forEach(element => {
             if (element.clientHeight !== undefined) {
                 const newTopValue = -1 * (element.clientHeight) + 'px';

--- a/frontend/js/behaviors/core/showAdmissionTooltip.js
+++ b/frontend/js/behaviors/core/showAdmissionTooltip.js
@@ -17,15 +17,14 @@ const showAdmissionTooltip = function(container) {
     }
 
     function hideTooltips() {
-        const tooltips = document.querySelectorAll('.admission-info-button-info.admission-info-visible');
-        if(infoOpen && !container.contains(document.activeElement)){
-            tooltips.forEach(element => {
-                infoOpen = false;
-                element.setAttribute('aria-expanded','false');
-                element.setAttribute('aria-hidden','true');
-                element.classList.remove('admission-info-visible')
-            })
-        }
+        const tooltips = document.querySelectorAll('.admission-info-button-info');
+        tooltips.forEach(element => {
+            infoOpen = false;
+            element.setAttribute('style', 'display: none');
+            element.setAttribute('aria-expanded','false');
+            element.setAttribute('aria-hidden','true');
+            element.classList.remove('admission-info-visible')
+        })
     }
 
     function showTooltip(targetTooltip) {
@@ -33,6 +32,7 @@ const showAdmissionTooltip = function(container) {
             infoOpen = true;
             targetTooltip.setAttribute('aria-expanded','true');
             targetTooltip.setAttribute('aria-hidden','false');
+            targetTooltip.setAttribute('style', 'display: block');
             targetTooltip.classList.add('admission-info-visible');
         }
     }
@@ -53,6 +53,7 @@ const showAdmissionTooltip = function(container) {
       }
 
     function _init() {
+        hideTooltips();
         document.addEventListener('click', hideTooltips, false);
         window.addEventListener('resize', sizeToolTips, false);
     }


### PR DESCRIPTION
While admission tooltips are not displayed visually, they're still layered in the DOM and cover up elements underneath, making them unclickable. This PR fixes the issue by adding `display: xxx` to the code logic that shows and hides tooltips.