### PR TITLE
Patch Twill to not use Node 10 syntax [WEB-2678]

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
             "package": {
                 "type": "metapackage",
                 "name": "vendor/package-patches",
-                "version": "1.2.0",
+                "version": "1.3.0",
                 "require": {
                     "netresearch/composer-patches-plugin": "~1.2"
                 },
@@ -32,7 +32,11 @@
                             {
                                 "title": "WEB-2638: Backport Node 14 syntax",
                                 "url": "patches/WEB-2638---backport-node-14-syntax.diff"
-                          }
+                            },
+                            {
+                                "title": "WEB-2678: Backport Node 10 syntax",
+                                "url": "patches/WEB-2678---backport-node-10-syntax.diff"
+                            }
                         ]
                     }
                 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b28f7040130b16e03062cd468f541546",
+    "content-hash": "11b5e30c6e3e8aafbcc25585fb1bae50",
     "packages": [
         {
             "name": "aic/data-hub-foundation",
@@ -11684,7 +11684,7 @@
         },
         {
             "name": "vendor/package-patches",
-            "version": "1.2.0",
+            "version": "1.3.0",
             "require": {
                 "netresearch/composer-patches-plugin": "~1.2"
             },
@@ -11699,6 +11699,10 @@
                         {
                             "title": "WEB-2638: Backport Node 14 syntax",
                             "url": "patches/WEB-2638---backport-node-14-syntax.diff"
+                        },
+                        {
+                            "title": "WEB-2678: Backport Node 10 syntax",
+                            "url": "patches/WEB-2678---backport-node-10-syntax.diff"
                         }
                     ]
                 }

--- a/patches/WEB-2678---backport-node-10-syntax.diff
+++ b/patches/WEB-2678---backport-node-10-syntax.diff
@@ -1,0 +1,14 @@
+diff --git a/frontend/js/libs/Quill/QuillConfiguration.js b/frontend/js/libs/Quill/QuillConfiguration.js
+index df8934b9..bc145ebb 100644
+--- a/frontend/js/libs/Quill/QuillConfiguration.js
++++ b/frontend/js/libs/Quill/QuillConfiguration.js
+@@ -119,8 +119,7 @@ class MyLink extends Link {
+ 
+     // url starting with the front-end base url wont have target blank
+     if (window[process.env.VUE_APP_NAME].STORE.form.baseUrl) {
+-      const url = new URL(window[process.env.VUE_APP_NAME].STORE.form.baseUrl)
+-      if (value.startsWith(url.origin)) {
++      if (value.startsWith(window[process.env.VUE_APP_NAME].STORE.form.baseUrl)) {
+         node.removeAttribute('target')
+       }
+     }


### PR DESCRIPTION
To apply this change to your local environment, simply run `composer install`