### PR TITLE
Create automatic relations between content [WEB-2699]

### DIFF
--- a/app/Models/Article.php
+++ b/app/Models/Article.php
@@ -12,6 +12,7 @@ use App\Models\Behaviors\HasRelated;
 use App\Models\Behaviors\HasApiRelations;
 use App\Models\Behaviors\HasFeaturedRelated;
 use App\Models\Behaviors\HasUnlisted;
+use App\Models\Vendor\Block;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Spatie\Feed\Feedable;
 use Spatie\Feed\FeedItem;
@@ -368,5 +369,43 @@ class Article extends AbstractModel implements Feedable
                 },
             ],
         ];
+    }
+
+    public function related($id)
+    {
+        $modelName = 'articles';
+
+        $blockableTypes = [
+            'landingPages',
+            'pressReleases',
+            'printedPublications',
+            'issueArticles',
+            'digitalPublicationSections',
+            'highlights',
+            'magazineIssues',
+            'educatorResources',
+            'articles',
+            'sponsors',
+            'exhibitionPressRooms',
+            'videos',
+            'researchGuides',
+            'genericPages',
+            'events',
+            'exhibitions',
+            'digitalPublications',
+        ];
+
+        $relatedBlockItems = Block::whereIn('blockable_type', $blockableTypes)
+            ->where('content', 'LIKE', '%"browsers"%')
+            ->where('content', 'LIKE', '%' . $modelName . '%')
+            ->where('content', 'LIKE', '%' . $id . '%')
+            ->get();
+
+        $relatedItems = [];
+        foreach ($relatedBlockItems as $relatedBlockItem) {
+            $relatedItems[] = $relatedBlockItem->blockable;
+        }
+
+        return $relatedItems;
     }
 }

--- a/app/Models/Article.php
+++ b/app/Models/Article.php
@@ -376,23 +376,14 @@ class Article extends AbstractModel implements Feedable
         $modelName = 'articles';
 
         $blockableTypes = [
-            'landingPages',
-            'pressReleases',
-            'printedPublications',
-            'issueArticles',
-            'digitalPublicationSections',
             'highlights',
-            'magazineIssues',
             'educatorResources',
             'articles',
-            'sponsors',
-            'exhibitionPressRooms',
             'videos',
             'researchGuides',
             'genericPages',
             'events',
             'exhibitions',
-            'digitalPublications',
         ];
 
         $relatedBlockItems = Block::whereIn('blockable_type', $blockableTypes)

--- a/app/Models/Article.php
+++ b/app/Models/Article.php
@@ -12,7 +12,7 @@ use App\Models\Behaviors\HasRelated;
 use App\Models\Behaviors\HasApiRelations;
 use App\Models\Behaviors\HasFeaturedRelated;
 use App\Models\Behaviors\HasUnlisted;
-use App\Models\Vendor\Block;
+use App\Models\Behaviors\HasAutoRelated;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Spatie\Feed\Feedable;
 use Spatie\Feed\FeedItem;
@@ -25,6 +25,7 @@ class Article extends AbstractModel implements Feedable
     use HasMediasEloquent;
     use HasBlocks;
     use Transformable;
+    use HasAutoRelated;
     use HasRelated;
     use HasApiRelations;
     use HasFeaturedRelated;
@@ -369,34 +370,5 @@ class Article extends AbstractModel implements Feedable
                 },
             ],
         ];
-    }
-
-    public function related($id)
-    {
-        $modelName = 'articles';
-
-        $blockableTypes = [
-            'highlights',
-            'educatorResources',
-            'articles',
-            'videos',
-            'researchGuides',
-            'genericPages',
-            'events',
-            'exhibitions',
-        ];
-
-        $relatedBlockItems = Block::whereIn('blockable_type', $blockableTypes)
-            ->where('content', 'LIKE', '%"browsers"%')
-            ->where('content', 'LIKE', '%' . $modelName . '%')
-            ->where('content', 'LIKE', '%' . $id . '%')
-            ->get();
-
-        $relatedItems = [];
-        foreach ($relatedBlockItems as $relatedBlockItem) {
-            $relatedItems[] = $relatedBlockItem->blockable;
-        }
-
-        return $relatedItems;
     }
 }

--- a/app/Models/Artwork.php
+++ b/app/Models/Artwork.php
@@ -147,24 +147,16 @@ class Artwork extends AbstractModel
     {
         $modelName = 'artworks';
 
+
         $blockableTypes = [
-            'landingPages',
-            'pressReleases',
-            'printedPublications',
-            'issueArticles',
-            'digitalPublicationSections',
             'highlights',
-            'magazineIssues',
             'educatorResources',
             'articles',
-            'sponsors',
-            'exhibitionPressRooms',
             'videos',
             'researchGuides',
             'genericPages',
             'events',
             'exhibitions',
-            'digitalPublications',
         ];
 
         $relatedBlockItems = Block::whereIn('blockable_type', $blockableTypes)

--- a/app/Models/Artwork.php
+++ b/app/Models/Artwork.php
@@ -8,6 +8,7 @@ use App\Models\Behaviors\HasRelated;
 use App\Models\Behaviors\HasApiRelations;
 use App\Models\Behaviors\HasFeaturedRelated;
 use App\Models\Behaviors\HasMedias;
+use App\Models\Vendor\Block;
 use App\Helpers\StringHelpers;
 
 class Artwork extends AbstractModel
@@ -140,5 +141,43 @@ class Artwork extends AbstractModel
                 },
             ],
         ];
+    }
+
+    public function related($id)
+    {
+        $modelName = 'artworks';
+
+        $blockableTypes = [
+            'landingPages',
+            'pressReleases',
+            'printedPublications',
+            'issueArticles',
+            'digitalPublicationSections',
+            'highlights',
+            'magazineIssues',
+            'educatorResources',
+            'articles',
+            'sponsors',
+            'exhibitionPressRooms',
+            'videos',
+            'researchGuides',
+            'genericPages',
+            'events',
+            'exhibitions',
+            'digitalPublications',
+        ];
+
+        $relatedBlockItems = Block::whereIn('blockable_type', $blockableTypes)
+            ->where('content', 'LIKE', '%"browsers"%')
+            ->where('content', 'LIKE', '%' . $modelName . '%')
+            ->where('content', 'LIKE', '%' . $id . '%')
+            ->get();
+
+        $relatedItems = [];
+        foreach ($relatedBlockItems as $relatedBlockItem) {
+            $relatedItems[] = $relatedBlockItem->blockable;
+        }
+
+        return $relatedItems;
     }
 }

--- a/app/Models/Artwork.php
+++ b/app/Models/Artwork.php
@@ -7,8 +7,8 @@ use App\Models\Behaviors\HasApiModel;
 use App\Models\Behaviors\HasRelated;
 use App\Models\Behaviors\HasApiRelations;
 use App\Models\Behaviors\HasFeaturedRelated;
+use App\Models\Behaviors\HasAutoRelated;
 use App\Models\Behaviors\HasMedias;
-use App\Models\Vendor\Block;
 use App\Helpers\StringHelpers;
 
 class Artwork extends AbstractModel
@@ -18,6 +18,7 @@ class Artwork extends AbstractModel
     use HasRelated;
     use HasApiRelations;
     use HasFeaturedRelated;
+    use HasAutoRelated;
     use HasMedias;
     use HasFiles;
 
@@ -141,35 +142,5 @@ class Artwork extends AbstractModel
                 },
             ],
         ];
-    }
-
-    public function related($id)
-    {
-        $modelName = 'artworks';
-
-
-        $blockableTypes = [
-            'highlights',
-            'educatorResources',
-            'articles',
-            'videos',
-            'researchGuides',
-            'genericPages',
-            'events',
-            'exhibitions',
-        ];
-
-        $relatedBlockItems = Block::whereIn('blockable_type', $blockableTypes)
-            ->where('content', 'LIKE', '%"browsers"%')
-            ->where('content', 'LIKE', '%' . $modelName . '%')
-            ->where('content', 'LIKE', '%' . $id . '%')
-            ->get();
-
-        $relatedItems = [];
-        foreach ($relatedBlockItems as $relatedBlockItem) {
-            $relatedItems[] = $relatedBlockItem->blockable;
-        }
-
-        return $relatedItems;
     }
 }

--- a/app/Models/Behaviors/HasAutoRelated.php
+++ b/app/Models/Behaviors/HasAutoRelated.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Models\Behaviors;
+
+use App\Models\Vendor\Block;
+use Illuminate\Support\Str;
+
+trait HasAutoRelated
+{
+    public function related($id)
+    {
+        $modelName = Str::plural(Str::lower(class_basename(__CLASS__)));;
+
+        $blockableTypes = [
+            'highlights',
+            'educatorResources',
+            'articles',
+            'videos',
+            'researchGuides',
+            'genericPages',
+            'events',
+            'exhibitions',
+        ];
+
+        $relatedBlockItems = Block::whereIn('blockable_type', $blockableTypes)
+            ->where('content', 'LIKE', '%"browsers"%')
+            ->where('content', 'LIKE', '%' . $modelName . '%')
+            ->where('content', 'LIKE', '%' . $id . '%')
+            ->get();
+
+        $relatedItems = [];
+        foreach ($relatedBlockItems as $relatedBlockItem) {
+            $relatedItems[] = $relatedBlockItem->blockable;
+        }
+
+        return $relatedItems;
+    }
+}
+
+?>

--- a/app/Models/Behaviors/HasAutoRelated.php
+++ b/app/Models/Behaviors/HasAutoRelated.php
@@ -10,7 +10,6 @@ trait HasAutoRelated
     public function related($id)
     {
         $modelName = Str::plural(Str::lower(class_basename(__CLASS__)));
-        ;
 
         $blockableTypes = [
             'highlights',

--- a/app/Models/Behaviors/HasAutoRelated.php
+++ b/app/Models/Behaviors/HasAutoRelated.php
@@ -9,7 +9,8 @@ trait HasAutoRelated
 {
     public function related($id)
     {
-        $modelName = Str::plural(Str::lower(class_basename(__CLASS__)));;
+        $modelName = Str::plural(Str::lower(class_basename(__CLASS__)));
+        ;
 
         $blockableTypes = [
             'highlights',
@@ -36,5 +37,3 @@ trait HasAutoRelated
         return $relatedItems;
     }
 }
-
-?>

--- a/app/Models/Exhibition.php
+++ b/app/Models/Exhibition.php
@@ -328,24 +328,16 @@ class Exhibition extends AbstractModel
     {
         $modelName = 'exhibitions';
 
+
         $blockableTypes = [
-            'landingPages',
-            'pressReleases',
-            'printedPublications',
-            'issueArticles',
-            'digitalPublicationSections',
             'highlights',
-            'magazineIssues',
             'educatorResources',
             'articles',
-            'sponsors',
-            'exhibitionPressRooms',
             'videos',
             'researchGuides',
             'genericPages',
             'events',
             'exhibitions',
-            'digitalPublications',
         ];
 
         $relatedBlockItems = Block::whereIn('blockable_type', $blockableTypes)

--- a/app/Models/Exhibition.php
+++ b/app/Models/Exhibition.php
@@ -12,7 +12,6 @@ use App\Models\Behaviors\HasMediasEloquent;
 use App\Models\Behaviors\HasRelated;
 use App\Models\Behaviors\HasApiRelations;
 use App\Models\Behaviors\HasFeaturedRelated;
-use App\Models\Behaviors\HasAutoRelated
 use Carbon\Carbon;
 use Illuminate\Support\Str;
 

--- a/app/Models/Exhibition.php
+++ b/app/Models/Exhibition.php
@@ -11,6 +11,7 @@ use App\Models\Behaviors\HasMediasEloquent;
 use App\Models\Behaviors\HasRelated;
 use App\Models\Behaviors\HasApiRelations;
 use App\Models\Behaviors\HasFeaturedRelated;
+use App\Models\Vendor\Block;
 use Carbon\Carbon;
 use Illuminate\Support\Str;
 
@@ -321,5 +322,43 @@ class Exhibition extends AbstractModel
             ->all();
 
         return in_array($this->datahub_id, $featuredIds);
+    }
+
+    public function related($id)
+    {
+        $modelName = 'exhibitions';
+
+        $blockableTypes = [
+            'landingPages',
+            'pressReleases',
+            'printedPublications',
+            'issueArticles',
+            'digitalPublicationSections',
+            'highlights',
+            'magazineIssues',
+            'educatorResources',
+            'articles',
+            'sponsors',
+            'exhibitionPressRooms',
+            'videos',
+            'researchGuides',
+            'genericPages',
+            'events',
+            'exhibitions',
+            'digitalPublications',
+        ];
+
+        $relatedBlockItems = Block::whereIn('blockable_type', $blockableTypes)
+            ->where('content', 'LIKE', '%"browsers"%')
+            ->where('content', 'LIKE', '%' . $modelName . '%')
+            ->where('content', 'LIKE', '%' . $id . '%')
+            ->get();
+
+        $relatedItems = [];
+        foreach ($relatedBlockItems as $relatedBlockItem) {
+            $relatedItems[] = $relatedBlockItem->blockable;
+        }
+
+        return $relatedItems;
     }
 }

--- a/app/Models/Exhibition.php
+++ b/app/Models/Exhibition.php
@@ -5,13 +5,14 @@ namespace App\Models;
 use A17\Twill\Models\Behaviors\HasRevisions;
 use A17\Twill\Models\Behaviors\HasSlug;
 use App\Models\Behaviors\HasApiModel;
+use App\Models\Behaviors\HasAutoRelated;
 use App\Models\Behaviors\HasBlocks;
 use App\Models\Behaviors\HasMedias;
 use App\Models\Behaviors\HasMediasEloquent;
 use App\Models\Behaviors\HasRelated;
 use App\Models\Behaviors\HasApiRelations;
 use App\Models\Behaviors\HasFeaturedRelated;
-use App\Models\Vendor\Block;
+use App\Models\Behaviors\HasAutoRelated
 use Carbon\Carbon;
 use Illuminate\Support\Str;
 
@@ -27,6 +28,7 @@ class Exhibition extends AbstractModel
     use HasRelated;
     use HasApiRelations;
     use HasFeaturedRelated;
+    use HasAutoRelated;
 
     protected $apiModel = 'App\Models\Api\Exhibition';
 
@@ -322,35 +324,5 @@ class Exhibition extends AbstractModel
             ->all();
 
         return in_array($this->datahub_id, $featuredIds);
-    }
-
-    public function related($id)
-    {
-        $modelName = 'exhibitions';
-
-
-        $blockableTypes = [
-            'highlights',
-            'educatorResources',
-            'articles',
-            'videos',
-            'researchGuides',
-            'genericPages',
-            'events',
-            'exhibitions',
-        ];
-
-        $relatedBlockItems = Block::whereIn('blockable_type', $blockableTypes)
-            ->where('content', 'LIKE', '%"browsers"%')
-            ->where('content', 'LIKE', '%' . $modelName . '%')
-            ->where('content', 'LIKE', '%' . $id . '%')
-            ->get();
-
-        $relatedItems = [];
-        foreach ($relatedBlockItems as $relatedBlockItem) {
-            $relatedItems[] = $relatedBlockItem->blockable;
-        }
-
-        return $relatedItems;
     }
 }

--- a/app/Models/Highlight.php
+++ b/app/Models/Highlight.php
@@ -313,22 +313,14 @@ class Highlight extends AbstractModel
         $modelName = 'highlights';
 
         $blockableTypes = [
-            'landingPages',
-            'pressReleases',
-            'printedPublications',
-            'issueArticles',
-            'digitalPublicationSections',
             'highlights',
             'educatorResources',
             'articles',
-            'sponsors',
-            'exhibitionPressRooms',
             'videos',
             'researchGuides',
             'genericPages',
             'events',
             'exhibitions',
-            'digitalPublications',
         ];
 
         $relatedBlockItems = Block::whereIn('blockable_type', $blockableTypes)

--- a/app/Models/Highlight.php
+++ b/app/Models/Highlight.php
@@ -5,6 +5,7 @@ namespace App\Models;
 use A17\Twill\Models\Behaviors\HasPosition;
 use A17\Twill\Models\Behaviors\HasRevisions;
 use A17\Twill\Models\Behaviors\HasSlug;
+use App\Models\Vendor\Block;
 use App\Models\Api\Artwork;
 use App\Models\Api\Search;
 use App\Models\Behaviors\HasAuthors;
@@ -305,5 +306,42 @@ class Highlight extends AbstractModel
                 },
             ],
         ];
+    }
+
+    public function related($id)
+    {
+        $modelName = 'highlights';
+
+        $blockableTypes = [
+            'landingPages',
+            'pressReleases',
+            'printedPublications',
+            'issueArticles',
+            'digitalPublicationSections',
+            'highlights',
+            'educatorResources',
+            'articles',
+            'sponsors',
+            'exhibitionPressRooms',
+            'videos',
+            'researchGuides',
+            'genericPages',
+            'events',
+            'exhibitions',
+            'digitalPublications',
+        ];
+
+        $relatedBlockItems = Block::whereIn('blockable_type', $blockableTypes)
+            ->where('content', 'LIKE', '%"browsers"%')
+            ->where('content', 'LIKE', '%' . $modelName . '%')
+            ->where('content', 'LIKE', '%' . $id . '%')
+            ->get();
+
+        $relatedItems = [];
+        foreach ($relatedBlockItems as $relatedBlockItem) {
+            $relatedItems[] = $relatedBlockItem->blockable;
+        }
+
+        return $relatedItems;
     }
 }

--- a/app/Models/Highlight.php
+++ b/app/Models/Highlight.php
@@ -5,7 +5,6 @@ namespace App\Models;
 use A17\Twill\Models\Behaviors\HasPosition;
 use A17\Twill\Models\Behaviors\HasRevisions;
 use A17\Twill\Models\Behaviors\HasSlug;
-use App\Models\Vendor\Block;
 use App\Models\Api\Artwork;
 use App\Models\Api\Search;
 use App\Models\Behaviors\HasAuthors;
@@ -14,6 +13,7 @@ use App\Models\Behaviors\HasMedias;
 use App\Models\Behaviors\HasMediasEloquent;
 use App\Models\Behaviors\HasRelated;
 use App\Models\Behaviors\HasApiRelations;
+use App\Models\Behaviors\HasAutoRelated;
 use App\Models\Behaviors\HasFeaturedRelated;
 use App\Models\Behaviors\HasUnlisted;
 
@@ -28,6 +28,7 @@ class Highlight extends AbstractModel
     use Transformable;
     use HasRelated;
     use HasApiRelations;
+    use HasAutoRelated;
     use HasFeaturedRelated;
     use HasUnlisted;
     use HasAuthors;
@@ -306,34 +307,5 @@ class Highlight extends AbstractModel
                 },
             ],
         ];
-    }
-
-    public function related($id)
-    {
-        $modelName = 'highlights';
-
-        $blockableTypes = [
-            'highlights',
-            'educatorResources',
-            'articles',
-            'videos',
-            'researchGuides',
-            'genericPages',
-            'events',
-            'exhibitions',
-        ];
-
-        $relatedBlockItems = Block::whereIn('blockable_type', $blockableTypes)
-            ->where('content', 'LIKE', '%"browsers"%')
-            ->where('content', 'LIKE', '%' . $modelName . '%')
-            ->where('content', 'LIKE', '%' . $id . '%')
-            ->get();
-
-        $relatedItems = [];
-        foreach ($relatedBlockItems as $relatedBlockItem) {
-            $relatedItems[] = $relatedBlockItem->blockable;
-        }
-
-        return $relatedItems;
     }
 }

--- a/app/Models/Video.php
+++ b/app/Models/Video.php
@@ -96,6 +96,11 @@ class Video extends AbstractModel
         return route('videos.show', ['id' => $this->id, 'slug' => $this->getSlug()], false);
     }
 
+    public function getTypeAttribute()
+    {
+        return 'video';
+    }
+
     protected function transformMappingInternal()
     {
         return [

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -64,11 +64,17 @@ class AppServiceProvider extends ServiceProvider
             'experiences' => 'App\Models\Experience',
 
             'digitalPublications' => 'App\Models\DigitalPublication',
+            'digitalPublicationSections' => 'App\Models\DigitalPublicationSection',
+            'magazineIssues' => 'App\Models\MagazineIssue',
+            'pressReleases' => 'App\Models\PressRelease',
             'printedPublications' => 'App\Models\PrintedPublication',
+            'researchGuides' => 'App\Models\ResearchGuide',
+            'sponsors' => 'App\Models\Sponsor',
 
             'educatorResources' => 'App\Models\EducatorResource',
             'videos' => 'App\Models\Video',
             'exhibitions' => 'App\Models\Exhibition',
+            'exhibitionPressRooms' => 'App\Models\ExhibitionPressRoom',
             'departments' => 'App\Models\Department',
             'blocks' => 'App\Models\Vendor\Block',
         ]);

--- a/database/migrations/2023_12_12_135550_update_morph_map.php
+++ b/database/migrations/2023_12_12_135550_update_morph_map.php
@@ -1,0 +1,86 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Facades\DB;
+
+return new class () extends Migration {
+    public function up(): void
+    {
+        DB::statement("UPDATE blocks SET blockable_type='exhibitionPressRooms' where blockable_type='App\Models\ExhibitionPressRoom'");
+        DB::statement("UPDATE related SET subject_type='exhibitionPressRooms' where subject_type='App\Models\ExhibitionPressRoom'");
+        DB::statement("UPDATE related SET related_type='exhibitionPressRooms' where related_type='App\Models\ExhibitionPressRoom'");
+        DB::statement("UPDATE api_relatables SET api_relatable_type='exhibitionPressRooms' where api_relatable_type='App\Models\ExhibitionPressRoom'");
+        DB::statement("UPDATE mediables SET mediable_type='exhibitionPressRooms' where mediable_type='App\Models\ExhibitionPressRoom'");
+
+        DB::statement("UPDATE blocks SET blockable_type='researchGuides' where blockable_type='App\Models\ResearchGuide'");
+        DB::statement("UPDATE related SET subject_type='researchGuides' where subject_type='App\Models\ResearchGuide'");
+        DB::statement("UPDATE related SET related_type='researchGuides' where related_type='App\Models\ResearchGuide'");
+        DB::statement("UPDATE api_relatables SET api_relatable_type='researchGuides' where api_relatable_type='App\Models\ResearchGuide'");
+        DB::statement("UPDATE mediables SET mediable_type='researchGuides' where mediable_type='App\Models\ResearchGuide'");
+
+        DB::statement("UPDATE blocks SET blockable_type='sponsors' where blockable_type='App\Models\Sponsor'");
+        DB::statement("UPDATE related SET subject_type='sponsors' where subject_type='App\Models\Sponsor'");
+        DB::statement("UPDATE related SET related_type='sponsors' where related_type='App\Models\Sponsor'");
+        DB::statement("UPDATE api_relatables SET api_relatable_type='sponsors' where api_relatable_type='App\Models\Sponsor'");
+        DB::statement("UPDATE mediables SET mediable_type='sponsors' where mediable_type='App\Models\Sponsor'");
+
+        DB::statement("UPDATE blocks SET blockable_type='digitalPublicationSections' where blockable_type='App\Models\DigitalPublicationSection'");
+        DB::statement("UPDATE related SET subject_type='digitalPublicationSections' where subject_type='App\Models\DigitalPublicationSection'");
+        DB::statement("UPDATE related SET related_type='digitalPublicationSections' where related_type='App\Models\DigitalPublicationSection'");
+        DB::statement("UPDATE api_relatables SET api_relatable_type='digitalPublicationSections' where api_relatable_type='App\Models\DigitalPublicationSection'");
+        DB::statement("UPDATE mediables SET mediable_type='digitalPublicationSections' where mediable_type='App\Models\DigitalPublicationSection'");
+
+        DB::statement("UPDATE blocks SET blockable_type='magazineIssues' where blockable_type='App\Models\MagazineIssue'");
+        DB::statement("UPDATE related SET subject_type='magazineIssues' where subject_type='App\Models\MagazineIssue'");
+        DB::statement("UPDATE related SET related_type='magazineIssues' where related_type='App\Models\MagazineIssue'");
+        DB::statement("UPDATE api_relatables SET api_relatable_type='magazineIssues' where api_relatable_type='App\Models\MagazineIssue'");
+        DB::statement("UPDATE mediables SET mediable_type='magazineIssues' where mediable_type='App\Models\MagazineIssue'");
+
+        DB::statement("UPDATE blocks SET blockable_type='pressReleases' where blockable_type='App\Models\PressRelease'");
+        DB::statement("UPDATE related SET subject_type='pressReleases' where subject_type='App\Models\PressRelease'");
+        DB::statement("UPDATE related SET related_type='pressReleases' where related_type='App\Models\PressRelease'");
+        DB::statement("UPDATE api_relatables SET api_relatable_type='pressReleases' where api_relatable_type='App\Models\PressRelease'");
+        DB::statement("UPDATE mediables SET mediable_type='pressReleases' where mediable_type='App\Models\PressRelease'");
+    }
+
+    public function down(): void
+    {
+        DB::statement("UPDATE blocks SET blockable_type='App\Models\ExhibitionPressRoom' where blockable_type='exhibitionPressRooms'");
+        DB::statement("UPDATE related SET subject_type='App\Models\ExhibitionPressRoom' where subject_type='exhibitionPressRooms'");
+        DB::statement("UPDATE related SET related_type='App\Models\ExhibitionPressRoom' where related_type='exhibitionPressRooms'");
+        DB::statement("UPDATE api_relatables SET api_relatable_type='App\Models\ExhibitionPressRoom' where api_relatable_type='exhibitionPressRooms'");
+        DB::statement("UPDATE mediables SET mediable_type='App\Models\ExhibitionPressRoom' where mediable_type='exhibitionPressRooms'");
+
+        DB::statement("UPDATE blocks SET blockable_type='App\Models\ResearchGuide' where blockable_type='researchGuides'");
+        DB::statement("UPDATE related SET subject_type='App\Models\ResearchGuide' where subject_type='researchGuides'");
+        DB::statement("UPDATE related SET related_type='App\Models\ResearchGuide' where related_type='researchGuides'");
+        DB::statement("UPDATE api_relatables SET api_relatable_type='App\Models\ResearchGuide' where api_relatable_type='researchGuides'");
+        DB::statement("UPDATE mediables SET mediable_type='App\Models\ResearchGuide' where mediable_type='researchGuides'");
+
+        DB::statement("UPDATE blocks SET blockable_type='App\Models\Sponsor' where blockable_type='sponsors'");
+        DB::statement("UPDATE related SET subject_type='App\Models\Sponsor' where subject_type='sponsors'");
+        DB::statement("UPDATE related SET related_type='App\Models\Sponsor' where related_type='sponsors'");
+        DB::statement("UPDATE api_relatables SET api_relatable_type='App\Models\Sponsor' where api_relatable_type='sponsors'");
+        DB::statement("UPDATE mediables SET mediable_type='App\Models\Sponsor' where mediable_type='sponsors'");
+
+        DB::statement("UPDATE blocks SET blockable_type='App\Models\DigitalPublicationSection' where blockable_type='digitalPublicationSections'");
+        DB::statement("UPDATE related SET subject_type='App\Models\DigitalPublicationSection' where subject_type='digitalPublicationSections'");
+        DB::statement("UPDATE related SET related_type='App\Models\DigitalPublicationSection' where related_type='digitalPublicationSections'");
+        DB::statement("UPDATE api_relatables SET api_relatable_type='App\Models\DigitalPublicationSection' where api_relatable_type='digitalPublicationSections'");
+        DB::statement("UPDATE mediables SET mediable_type='App\Models\DigitalPublicationSection' where mediable_type='digitalPublicationSections'");
+
+        DB::statement("UPDATE blocks SET blockable_type='App\Models\MagazineIssue' where blockable_type='magazineIssues'");
+        DB::statement("UPDATE related SET subject_type='App\Models\MagazineIssue' where subject_type='magazineIssues'");
+        DB::statement("UPDATE related SET related_type='App\Models\MagazineIssue' where related_type='magazineIssues'");
+        DB::statement("UPDATE api_relatables SET api_relatable_type='App\Models\MagazineIssue' where api_relatable_type='magazineIssues'");
+        DB::statement("UPDATE mediables SET mediable_type='App\Models\MagazineIssue' where mediable_type='magazineIssues'");
+
+        DB::statement("UPDATE blocks SET blockable_type='App\Models\PressRelease' where blockable_type='pressReleases'");
+        DB::statement("UPDATE related SET subject_type='App\Models\PressRelease' where subject_type='pressReleases'");
+        DB::statement("UPDATE related SET related_type='App\Models\PressRelease' where related_type='pressReleases'");
+        DB::statement("UPDATE api_relatables SET api_relatable_type='App\Models\PressRelease' where api_relatable_type='pressReleases'");
+        DB::statement("UPDATE mediables SET mediable_type='App\Models\PressRelease' where mediable_type='pressReleases'");
+    }
+};

--- a/database/migrations/2024_01_03_101154_add_intro_column_to_landing_pages_table.php
+++ b/database/migrations/2024_01_03_101154_add_intro_column_to_landing_pages_table.php
@@ -4,8 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-return new class extends Migration
-{
+return new class () extends Migration {
     public function up(): void
     {
         Schema::table('landing_pages', function (Blueprint $table) {

--- a/resources/views/components/molecules/_m-listing----auto-related.blade.php
+++ b/resources/views/components/molecules/_m-listing----auto-related.blade.php
@@ -1,5 +1,12 @@
+@php
+    if (method_exists($item, 'getAugmentedModel')) {
+        $route = route($item->getAugmentedModel()->getMorphClass() .'.show', $item);
+    } else {
+        $route = route($item->getMorphClass() .'.show', $item);
+    }
+@endphp
 <{{ $tag ?? 'li' }} class="m-listing m-listing--article{{ (isset($variation)) ? ' '.$variation : '' }}"{!! (isset($variation) and strrpos($variation, "--hero") > -1 and !$item->videoFront) ? ' data-behavior="blurMyBackground"' : '' !!}>
-    <a href="{!! route(($module ?? $item->getMorphClass()) .'.show', $item) !!}" class="m-listing__link"{!! (isset($gtmAttributes)) ? ' '.$gtmAttributes.'' : '' !!}>
+    <a href="{!! $route !!}" class="m-listing__link"{!! (isset($gtmAttributes)) ? ' '.$gtmAttributes.'' : '' !!}>
         @if ($isFeatured)
             <span class="m-listing__img{{ (isset($imgVariation)) ? ' '.$imgVariation : '' }}{{ ($item->videoFront) ? ' m-listing__img--video' : '' }}"{{ (isset($variation) and strrpos($variation, "--hero") > -1 and !$item->videoFront) ? ' data-blur-img' : '' }}>
                 @if (isset($image) || $item->imageFront('hero'))

--- a/resources/views/components/molecules/_m-listing----auto-related.blade.php
+++ b/resources/views/components/molecules/_m-listing----auto-related.blade.php
@@ -38,7 +38,7 @@
             </span>
         @endif
         <div class="m-listing__meta"{{ (isset($variation) and strrpos($variation, "--hero") > -1) ? ' data-blur-clip-to' : '' }}>
-            <em class="type f-tag">{!! $subtype ?? $item->present()->subtype !!}</em>
+            <em class="type f-tag">{!! $item->subtype ? $item->present()->subtype : $item->type !!}</em>
             <br>
             @component('components.atoms._title')
                 @slot('font', $titleFont ?? 'f-list-3')

--- a/resources/views/components/molecules/_m-listing----auto-related.blade.php
+++ b/resources/views/components/molecules/_m-listing----auto-related.blade.php
@@ -1,0 +1,49 @@
+<{{ $tag ?? 'li' }} class="m-listing m-listing--article{{ (isset($variation)) ? ' '.$variation : '' }}"{!! (isset($variation) and strrpos($variation, "--hero") > -1 and !$item->videoFront) ? ' data-behavior="blurMyBackground"' : '' !!}>
+    <a href="{!! route(($module ?? $item->getMorphClass()) .'.show', $item) !!}" class="m-listing__link"{!! (isset($gtmAttributes)) ? ' '.$gtmAttributes.'' : '' !!}>
+        @if ($isFeatured)
+            <span class="m-listing__img{{ (isset($imgVariation)) ? ' '.$imgVariation : '' }}{{ ($item->videoFront) ? ' m-listing__img--video' : '' }}"{{ (isset($variation) and strrpos($variation, "--hero") > -1 and !$item->videoFront) ? ' data-blur-img' : '' }}>
+                @if (isset($image) || $item->imageFront('hero'))
+                    @if ($isHero ?? false)
+                        @component('components.atoms._img')
+                            @slot('image', $image ?? $item->imageFront('hero'))
+                            @slot('settings', $imageSettings ?? '')
+                            @slot('class', 'img-hero-desktop')
+                        @endcomponent
+                        @component('components.atoms._img')
+                            @slot('image', $imageMobile ?? $item->imageFront('mobile_hero') ?? $image ?? $item->imageFront('hero'))
+                            @slot('settings', $imageSettings ?? '')
+                            @slot('class', 'img-hero-mobile')
+                        @endcomponent
+                    @else 
+                        @component('components.atoms._img')
+                            @slot('image', $image ?? $item->imageFront('hero'))
+                            @slot('settings', $imageSettings ?? '')
+                        @endcomponent
+                    @endif
+                    @component('components.molecules._m-listing-video')
+                        @slot('item', $item)
+                        @slot('image', $image ?? null)
+                    @endcomponent
+                @else
+                    <span class="default-img"></span>
+                @endif
+                <span class="m-listing__img__overlay"></span>
+            </span>
+        @endif
+        <div class="m-listing__meta"{{ (isset($variation) and strrpos($variation, "--hero") > -1) ? ' data-blur-clip-to' : '' }}>
+            <em class="type f-tag">{!! $subtype ?? $item->present()->subtype !!}</em>
+            <br>
+            @component('components.atoms._title')
+                @slot('font', $titleFont ?? 'f-list-3')
+                @slot('title', $item->present()->title)
+                @slot('title_display', $item->present()->title_display)
+            @endcomponent
+            <br>
+            @if ($isFeatured)
+                @if ($item->present()->list_description)
+                    <div class="intro {{ $captionFont ?? 'f-caption' }}">{!! $item->present()->list_description !!}</div>
+                @endif
+            @endif
+        </div>
+    </a>
+</{{ $tag ?? 'li' }}>

--- a/resources/views/site/shared/_featuredRelated.blade.php
+++ b/resources/views/site/shared/_featuredRelated.blade.php
@@ -17,28 +17,50 @@
     if (($behavior ?? '') === 'relatedSidebar') {
         $listingVariation .= ' m-listing--dynamic';
     }
+
+    // Get featured related items
+    $isFeatured = false;
+    $featuredRelated = collect($item->getFeaturedRelated())->map(function ($featuredRelated) {
+        return $featuredRelated['item'];
+    });
+    $featuredRelatedIds = $featuredRelated->pluck('id');
+
+    // Get auto related items & evaluate if they are featured
+
+    $autoRelated = collect($item->related($item->id))->unique('id');
+
+    // Remove featured related items from auto related items
+    if ($featuredRelatedIds->isNotEmpty()) {
+        $autoRelated = $autoRelated->reject(function ($relatedItem) use ($featuredRelatedIds) {
+            return $featuredRelatedIds->contains($relatedItem->id);
+        });
+    }
 @endphp
 
-@if (method_exists($item, 'hasFeaturedRelated') && $item->hasFeaturedRelated())
+@if (method_exists($item, 'hasFeaturedRelated') && $item->hasFeaturedRelated() || count($autoRelated) > 0)
     <aside class="m-inline-aside{{ (isset($variation)) ? ' '.$variation : '' }}" {!! (isset($behavior)) ? 'data-behavior="'.$behavior.'"' : '' !!}>
-        @component('components.atoms._hr')
-        @endcomponent
+            @component('components.atoms._hr')
+            @endcomponent
         @component('components.blocks._text')
             @slot('font', 'f-module-title-1')
             @slot('tag', 'h4')
             {{ $item->getFeaturedRelatedTitle() }}
         @endcomponent
         @component('components.organisms._o-row-listing')
-            @foreach ($item->getFeaturedRelated() as $related)
-                @component('components.molecules._m-listing----' . strtolower($related['type']))
-                    @slot('item', $related['item'])
+            @foreach ($featuredRelated->concat($autoRelated)->take(6) as $related)
+                @php
+                    $isFeatured = $loop->first;
+                @endphp
+                @component('components.molecules._m-listing----auto-related')
+                    @slot('isFeatured', $isFeatured)
+                    @slot('item', $related['item'] ?? $related)
                     @slot('variation',  $listingVariation)
                     @slot('fullscreen', false)
-                    @slot('titleFont', $loop->index > 0 ? 'f-list-1' : 'f-list-3')
+                    @slot('titleFont', $isFeatured ? 'f-list-3' : 'f-list-1')
                     @slot('hideImage', $loop->index > 0)
                     @slot('hideDescription', $loop->index > 0)
                     @slot('imageSettings', $imageSettings ?? null)
-                    @slot('gtmAttributes', $item->getFeaturedRelatedGtmAttributes())
+                    @slot('gtmAttributes', $isFeatured ? ($item->getFeaturedRelatedGtmAttributes() ?? null) : (method_exists($related, 'getFeaturedRelatedGtmAttributes') ? $related->getFeaturedRelatedGtmAttributes() : null))
                 @endcomponent
             @endforeach
         @endcomponent

--- a/resources/views/site/shared/_featuredRelated.blade.php
+++ b/resources/views/site/shared/_featuredRelated.blade.php
@@ -39,8 +39,8 @@
 
 @if (method_exists($item, 'hasFeaturedRelated') && $item->hasFeaturedRelated() || count($autoRelated) > 0)
     <aside class="m-inline-aside{{ (isset($variation)) ? ' '.$variation : '' }}" {!! (isset($behavior)) ? 'data-behavior="'.$behavior.'"' : '' !!}>
-            @component('components.atoms._hr')
-            @endcomponent
+        @component('components.atoms._hr')
+        @endcomponent
         @component('components.blocks._text')
             @slot('font', 'f-module-title-1')
             @slot('tag', 'h4')


### PR DESCRIPTION
The work here will search for content with browsers that match the model and id of content. Once it's found we'll render it on the sidebar in the FE with priority given to `custom_related` content in the CMS.