### PR TITLE
Custom tours: Update reference to custom-tours-builder #main

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2448,8 +2448,8 @@
       "integrity": "sha512-TDDkd5DkaZxZFM8p+1I3yAlvM3rSr1wbrOliG4yJiwinMZN8z/iGL7BTlDkrJcYTmgUSb4ywVCc3ZaUtOtC76w=="
     },
     "custom-tour-builder": {
-      "version": "git+https://github.com/art-institute-of-chicago/custom-tours.git#93e2e21fdccbd5f61618fcb3cebd49741fa2de6d",
-      "from": "git+https://github.com/art-institute-of-chicago/custom-tours.git#develop",
+      "version": "git+https://github.com/art-institute-of-chicago/custom-tours.git#b0e1d4b01ae7d85b09e3fe10c1135842ab2d9a8b",
+      "from": "git+https://github.com/art-institute-of-chicago/custom-tours.git#main",
       "requires": {
         "classnames": "^2.3.2",
         "prop-types": "^15.8.1"

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "chalk": "^2.2.0",
     "closer-look": "git+ssh://git@github.com/art-institute-of-chicago/digital-labels-ui.git#master",
     "cross-spawn": "^6.0.5",
-    "custom-tour-builder": "git+https://github.com/art-institute-of-chicago/custom-tours.git#develop",
+    "custom-tour-builder": "git+https://github.com/art-institute-of-chicago/custom-tours.git#main",
     "del": "^3.0.0",
     "fitty": "^2.3.0",
     "fs-extra": "^5.0.0",


### PR DESCRIPTION
This is to point the custom-tours-builder React app at the code in `main` on [art-institute-of-chicago/custom-tours ](https://github.com/art-institute-of-chicago/custom-tours)