### PR TITLE
Add a div wrapper to the paragraph block html

### DIFF
--- a/resources/views/site/blocks/paragraph.blade.php
+++ b/resources/views/site/blocks/paragraph.blade.php
@@ -81,6 +81,10 @@
     libxml_clear_errors();
     libxml_use_internal_errors($oldInternalErrors);
 @endphp
+@if (isset($hasWrapper) && $hasWrapper)
 <div class="paragraph-wrapper">
     {!! $content !!}
 </div>
+@else
+    {!! $content !!}
+@endif

--- a/resources/views/site/blocks/paragraph.blade.php
+++ b/resources/views/site/blocks/paragraph.blade.php
@@ -81,4 +81,6 @@
     libxml_clear_errors();
     libxml_use_internal_errors($oldInternalErrors);
 @endphp
-{!! $content !!}
+<div class="paragraph-wrapper">
+    {!! $content !!}
+</div>


### PR DESCRIPTION
@nikhiltri & @web-dev-trev I need this wrapper div in order to be able to properly style paragraphs for the RLC page, but I'm afraid that adding this might disrupt styling for existing paragraph blocks.