### PR TITLE
Replace img/video components with media component

### DIFF
--- a/frontend/scss/pages/types/_t-rlc.scss
+++ b/frontend/scss/pages/types/_t-rlc.scss
@@ -280,6 +280,11 @@
       .m-showcase-media {
         margin-top: 0;
         min-width: unset;
+
+        @include breakpoint('xsmall') {
+          min-width: 100%;
+        }
+
         img, video {
           padding: 0;
           width: 100%;

--- a/frontend/scss/pages/types/_t-rlc.scss
+++ b/frontend/scss/pages/types/_t-rlc.scss
@@ -227,7 +227,7 @@
       line-height: 28px;
       padding-top: 20px;
     }
-    .m-showcase-image, .m-showcase-video, .m-showcase-block__text-wrapper {
+    .m-showcase-media, .m-showcase-block__text-wrapper {
       margin: 0;
       padding: 0;
       @include breakpoint('small+') {
@@ -258,7 +258,7 @@
       .showcase-header {
         flex-basis: 100%;
       }
-      .m-showcase-image, .m-showcase-video, .m-showcase-block__text-wrapper {
+      .m-showcase-media, .m-showcase-block__text-wrapper {
         flex: 1 1;
       }
       @include breakpoint('xsmall') {
@@ -272,6 +272,19 @@
   .m-showcase-multiple-block {
     .m-showcase-wrapper {
       display: grid;
+    }
+  }
+  .m-showcase-block,
+  .m-showcase-multiple-block {
+    .m-showcase-wrapper {
+      .m-showcase-media {
+        margin-top: 0;
+        min-width: unset;
+        img, video {
+          padding: 0;
+          width: 100%;
+        }
+      }
     }
   }
   #about-the-r-l-c {
@@ -290,7 +303,13 @@
         }
       }
     }
-    .m-showcase-video {
+    .m-showcase-media {
+      .m-media__img {
+        background-color: inherit;
+        img {
+          aspect-ratio: 1;
+        }
+      }
       @include breakpoint('small+') {
         flex: 2;
       }
@@ -301,6 +320,13 @@
     .showcase-description,
     .showcase-link {
       color: $color__white;
+    }
+  }
+  #featured-events {
+    .m-showcase-media {
+      img {
+        aspect-ratio: 1;
+      }
     }
   }
   #make-with-us {
@@ -318,11 +344,13 @@
       grid-column-end: 3;
       grid-column-start: 1;
     }
-    .m-showcase-image {
-      aspect-ratio: 1;
+    .m-showcase-media {
       @include breakpoint('xsmall') {
         grid-column-end: 3;
         grid-column-start: 1;
+      }
+      img {
+        aspect-ratio: 1;
       }
     }
     .m-showcase-block__text-wrapper {
@@ -353,22 +381,24 @@
       grid-column-start: 1;
     }
     @include breakpoint('small+') {
-      img:nth-of-type(1) {
-        aspect-ratio: 1;
+      .m-showcase-media:nth-of-type(1) {
+        img {
+          aspect-ratio: 1;
+        }
       }
-      img:nth-of-type(2) {
+      .m-showcase-media:nth-of-type(2) {
         grid-column: 1;
         grid-row: 3;
         object-fit: contain;
       }
-      img:nth-of-type(3) {
+      .m-showcase-media:nth-of-type(3) {
         grid-column: 2;
         grid-row: 3;
         object-fit: contain;
       }
     }
     @include breakpoint('xsmall') {
-      .m-showcase-image,
+      .m-showcase-media,
       .m-showcase-block__text-wrapper {
         grid-column-end: 3;
         grid-column-start: 1;
@@ -387,27 +417,29 @@
       grid-column-end: 3;
       grid-column-start: 1;
     }
-    .m-showcase-image {
-      aspect-ratio: 1;
+    .m-showcase-media {
       clip-path: circle();
       margin: auto;
+      img {
+        aspect-ratio: 1;
+      }
       @include breakpoint('small+') {
         max-width: 75%;
       }
     }
-    img:nth-of-type(1) {
+    .m-showcase-media:nth-of-type(1) {
       grid-column: 1;
       grid-row: 2;
     }
-    img:nth-of-type(2) {
+    .m-showcase-media:nth-of-type(2) {
       grid-column: 2;
       grid-row: 2;
     }
-    img:nth-of-type(3) {
+    .m-showcase-media:nth-of-type(3) {
       grid-column: 1;
       grid-row: 4;
     }
-    img:nth-of-type(4) {
+    .m-showcase-media:nth-of-type(4) {
       grid-column: 2;
       grid-row: 4;
     }

--- a/frontend/scss/pages/types/_t-rlc.scss
+++ b/frontend/scss/pages/types/_t-rlc.scss
@@ -280,11 +280,9 @@
       .m-showcase-media {
         margin-top: 0;
         min-width: unset;
-
         @include breakpoint('xsmall') {
           min-width: 100%;
         }
-
         img, video {
           padding: 0;
           width: 100%;

--- a/resources/views/admin/blocks/showcase.blade.php
+++ b/resources/views/admin/blocks/showcase.blade.php
@@ -14,32 +14,13 @@
     'options' => collect(['image' => 'Image', 'video' => 'Video']),
 ])
 
-@formConnectedFields([
-    'fieldName' => 'media_type',
-    'fieldValues' => 'image',
-    'renderForBlocks' => true,
+@formField('medias', [
+    'name' => 'image',
+    'label' => 'Media',
+    'max' => 1,
+    'withVideoUrl' => false,
+    'required' => true,
 ])
-    @formField('medias', [
-        'name' => 'image',
-        'label' => 'Image',
-        'max' => 1,
-        'withVideoUrl' => false,
-        'required' => true,
-    ])
-@endcomponent
-
-@formConnectedFields([
-    'fieldName' => 'media_type',
-    'fieldValues' => 'video',
-    'renderForBlocks' => true,
-])
-    @formField('files', [
-        'name' => 'video',
-        'label' => 'Video',
-        'max' => 1,
-        'required' => true,
-    ])
-@endcomponent
 
 @formField('input', [
     'name' => 'tag',

--- a/resources/views/admin/repeaters/showcase_item.blade.php
+++ b/resources/views/admin/repeaters/showcase_item.blade.php
@@ -9,32 +9,13 @@
     'options' => collect(['image' => 'Image', 'video' => 'Video']),
 ])
 
-@formConnectedFields([
-    'fieldName' => 'media_type',
-    'fieldValues' => 'image',
-    'renderForBlocks' => true,
+@formField('medias', [
+    'name' => 'image',
+    'label' => 'Media',
+    'max' => 1,
+    'withVideoUrl' => false,
+    'required' => true,
 ])
-    @formField('medias', [
-        'name' => 'image',
-        'label' => 'Image',
-        'max' => 1,
-        'withVideoUrl' => false,
-        'required' => true,
-    ])
-@endcomponent
-
-@formConnectedFields([
-    'fieldName' => 'media_type',
-    'fieldValues' => 'video',
-    'renderForBlocks' => true,
-])
-    @formField('files', [
-        'name' => 'video',
-        'label' => 'Video',
-        'max' => 1,
-        'required' => true,
-    ])
-@endcomponent
 
 @formField('input', [
     'name' => 'tag',

--- a/resources/views/site/blocks/showcase.blade.php
+++ b/resources/views/site/blocks/showcase.blade.php
@@ -1,8 +1,7 @@
 @php
     $header = $block->input('header');
     $mediaType = $block->input('media_type');
-    $image = $block->imageAsArray('image', 'desktop');
-    $video = $block->file('video');
+    $media = $block->imageAsArray('image', 'desktop');
     $title = $block->input('title');
     $description = $block->input('description');
     $tag = $block->input('tag');
@@ -15,19 +14,15 @@
         @if ($header)
             <h3 class="showcase-header">{{ $header }}</h3>
         @endif
-        @if ($mediaType == 'video')
-            @component('components.atoms._video')
-                @slot('video', ['src' => $video])
-                @slot('controls', true)
-                @slot('class', 'm-showcase-video')
-            @endcomponent
-        @else
-            @component('components.atoms._img')
-                @slot('image', $image)
-                @slot('settings', $imageSettings ?? '')
-                @slot('class', 'm-showcase-image')
-            @endcomponent
-        @endif
+        @component('components.molecules._m-media')
+            @slot('variation', 'm-showcase-media')
+            @slot('item', [
+                'type' => $mediaType,
+                'media' => $media,
+                'loop' => true,
+                'loop_or_once' => 'loop',
+            ])
+        @endcomponent
         <div class="m-showcase-block__text-wrapper">
             @if ($tag)
                 @component('components.atoms._title')

--- a/resources/views/site/blocks/showcase_multiple.blade.php
+++ b/resources/views/site/blocks/showcase_multiple.blade.php
@@ -15,18 +15,15 @@
                 @endif
             </div>
             @foreach ($block->childs as $item)
-                @if ($item->input('media_type') == 'video')
-                    @component('components.atoms._video')
-                        @slot('video', ['src' => $item->file('video')])
-                        @slot('controls', true)
-                        @slot('class', 'm-showcase-video')
-                    @endcomponent
-                @else
-                    @component('components.atoms._img')
-                        @slot('image', $item->imageAsArray('image', 'desktop'))
-                        @slot('class', 'm-showcase-image')
-                    @endcomponent
-                @endif
+                @component('components.molecules._m-media')
+                    @slot('variation', 'm-showcase-media')
+                    @slot('item', [
+                        'type' => $item->input('media_type'),
+                        'media' => $item->imageAsArray('image', 'desktop'),
+                        'loop' => true,
+                        'loop_or_once' => 'loop',
+                    ])
+                @endcomponent
                 <div class="m-showcase-block__text-wrapper">
                     @if ($tag = $item->input('tag'))
                         @component('components.atoms._title')


### PR DESCRIPTION
@nikhiltri & @web-dev-trev I've been struggling with one small bit of this change all day, and I need some help to figure this out. I've replaced the `atoms._video` and `atoms._img` components with the `molecules._m-media` component in the showcase and showcase-multiple templates. For the _About the RLC_ section, I've gotten every thing to look good at the desktop breakpoints:
<img width="1171" alt="Screenshot 2024-02-08 at 5 59 58 PM" src="https://github.com/art-institute-of-chicago/artic.edu/assets/2098951/6d6f4ee1-0ec8-4564-b228-ee290fbf2665">
But on the mobile breakpoint, I can't for the life of me get the section to fully contain the video; it bleeds over into the next section, covering up its header:
<img width="324" alt="Screenshot 2024-02-08 at 6 05 03 PM" src="https://github.com/art-institute-of-chicago/artic.edu/assets/2098951/7366d570-ca68-4a3a-b67c-2366713f1970">
I've been banging my head against a wall all day, so I'm hoping you two might be able to fiddle with the CSS and figure out a solution.