### PR TITLE
Replacing single quotes with apostrophes

### DIFF
--- a/resources/views/site/blocks/showcase.blade.php
+++ b/resources/views/site/blocks/showcase.blade.php
@@ -1,18 +1,18 @@
 @php
-    $heading = $block->input('heading');
+    $heading = $block->present()->input('heading');
     $mediaType = $block->input('media_type');
     $media = $block->imageAsArray('image', 'desktop');
-    $title = $block->input('title');
-    $description = $block->input('description');
+    $title = $block->present()->input('title');
+    $description = $block->present()->input('description');
     $tag = $block->input('tag');
-    $linkLabel = $block->input('link_label');
+    $linkLabel = $block->present()->input('link_label');
     $linkUrl = $block->input('link_url');
 @endphp
 
 <div id="{{ str(strip_tags($heading))->kebab() }}" class="m-showcase-block">
     <div class="m-showcase-wrapper">
         @if ($heading)
-            <h3 id="{{ Str::slug(strip_tags($heading)) }}" class="showcase-header">{{ $heading }}</h3>
+            <h3 id="{{ Str::slug(strip_tags($heading)) }}" class="showcase-header">{!! $heading !!}</h3>
         @endif
         @if ($landingPageType == 'rlc')
             @component('components.molecules._m-media')

--- a/resources/views/site/blocks/showcase_multiple.blade.php
+++ b/resources/views/site/blocks/showcase_multiple.blade.php
@@ -1,6 +1,6 @@
 @php
-    $heading = $block->input('heading');
-    $intro = $block->input('intro');
+    $heading = $block->present()->input('heading');
+    $intro = $block->present()->input('intro');
 @endphp
 
 <div id="{{ str($block->input('id'))->after('#') }}" class="m-showcase-multiple-block">
@@ -8,10 +8,10 @@
         <div class="m-showcase-wrapper">
             <div class="m-showcase-block__header-wrapper">
                 @if ($heading)
-                    <h3 class="showcase-header">{{ $heading }}</h3>
+                    <h3 class="showcase-header">{!!$heading !!}</h3>
                 @endif
                 @if ($intro)
-                    <h4 class="showcase-intro">{{ $intro }}</h4>
+                    <h4 class="showcase-intro">{!! $intro !!}</h4>
                 @endif
             </div>
             @foreach ($block->childs as $item)
@@ -23,7 +23,6 @@
                     @slot('item', [
                         'type' => $item->input('media_type'),
                         'media' => $media,
-                        'caption' => $media['caption'],
                         'loop' => true,
                         'loop_or_once' => 'loop',
                     ])
@@ -37,7 +36,7 @@
                             @slot('title', $tag)
                         @endcomponent
                     @endif
-                    @if ($title = $item->input('title'))
+                    @if ($title = $item->present()->input('title'))
                         @component('components.atoms._title')
                             @slot('tag', 'div')
                             @slot('font', 'f-headline-editorial')
@@ -45,7 +44,7 @@
                             @slot('title', $title)
                         @endcomponent
                     @endif
-                    @if ($description = $item->input('description'))
+                    @if ($description = $item->present()->input('description'))
                         @component('components.blocks._text')
                             @slot('tag', 'div')
                             @slot('font', 'f-secondary')
@@ -54,7 +53,7 @@
                         @endcomponent
                     @endif
                     @php
-                        $linkLabel = $item->input('link_label');
+                        $linkLabel = $item->present()->input('link_label');
                         $linkUrl = $item->input('link_url');
                     @endphp
                     @if ($linkLabel || $linkUrl)


### PR DESCRIPTION
~~I'm working on using the presenters to replace single quotes with apostrophes in the showcase/showcase_multiple blocks. This works in some places, but not in others:
<img width="1517" alt="Screenshot 2024-02-21 at 12 38 53 PM" src="https://github.com/art-institute-of-chicago/artic.edu/assets/2098951/c697e681-6e2d-4c0a-aa32-e987cd1f0891">
<img width="1099" alt="Screenshot 2024-02-21 at 12 39 22 PM" src="https://github.com/art-institute-of-chicago/artic.edu/assets/2098951/c9f45be9-2489-4be2-961d-d965e4e95a92">
...namely it works in the `title`, `description`, and `link_label` fields, but not in the `header` and `intro` fields. I'm not able to locate where this transformation actually happens. The `BlockPresenter` does apparently transform the `description` with SmartyPants (https://github.com/art-institute-of-chicago/artic.edu/blob/develop/app/Presenters/Admin/BlockPresenter.php#L16), but then how are the `title` and `link_label` being transformed?~~

Nevermind, this was a PEBCAK error.