### PR TITLE
Fix article categories [WEB-2832]

### DIFF
--- a/app/Models/Page.php
+++ b/app/Models/Page.php
@@ -358,7 +358,7 @@ class Page extends AbstractModel
 
     public function articlesCategories()
     {
-        return $this->belongsToMany('App\Models\Category', 'page_article_category')->withPivot('position')->orderBy('position');
+        return $this->belongsToMany(\App\Models\Category::class, 'page_article_category')->withPivot('position')->orderBy('position');
     }
 
     public function artArticles()

--- a/app/Repositories/PageRepository.php
+++ b/app/Repositories/PageRepository.php
@@ -67,6 +67,7 @@ class PageRepository extends ModuleRepository
         // Homepage landing
         'homeVideos',
         'homeHighlights',
+        'articlesCategories'
     ];
 
     protected $apiBrowsers = [
@@ -106,7 +107,6 @@ class PageRepository extends ModuleRepository
             'moduleName' => 'categoryTerms',
             'routePrefix' => 'collection',
         ],
-
     ];
 
     protected $repeaters = [
@@ -162,6 +162,8 @@ class PageRepository extends ModuleRepository
             'experiences' => false
         ]);
 
+        $this->updateOrderedBelongsTomany($object, $fields, 'articlesCategories', 'position', 'Category');
+
         parent::afterSave($object, $fields);
     }
 
@@ -174,6 +176,8 @@ class PageRepository extends ModuleRepository
             'articles' => false,
             'experiences' => false
         ]);
+
+        $fields['browsers']['articlesCategories'] = $this->getFormFieldsForBrowser($object, 'articlesCategories', 'collection.articles_publications', 'name', 'categories');
 
         return $fields;
     }

--- a/resources/views/site/articles.blade.php
+++ b/resources/views/site/articles.blade.php
@@ -3,7 +3,9 @@
 @section('content')
 
 @php
-  $currentCategory = $page->articlesCategories->where('id', request()->query('category'))->pluck('name')->first();
+  $category = new \App\Models\Category;
+
+  $currentCategory = $category->where('id', request()->query('category'))->pluck('name')->first();
   $currentType = request()->query('type') ? ucfirst(request()->query('type')) : null;
 @endphp
 


### PR DESCRIPTION
This was a bug I found digging into article category queries. The landing page form for Articles was not loading the categories it was saving anymore and was defaulting to the unlinked set of data for categories. This ensures that on save and update the categories are linked and loaded back in. 

On the FE those selections are shown in the dropdown but you can also query for categories outside of the dropdown categories.