### PR TITLE
Fix PrinceXML installation

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -2,7 +2,7 @@ name: Testing
 on: [push]
 jobs:
     test:
-        runs-on: ubuntu-20.04
+        runs-on: ubuntu-22.04
         steps:
             - name: Install PHP
               uses: shivammathur/setup-php@v2
@@ -25,8 +25,8 @@ jobs:
             - name: Install Prince
               run: |
                   TEMP_PRINCE="$(mktemp)"
-                  sudo apt-get install gdebi lintian -y
-                  wget https://www.princexml.com/download/prince_15.3-1_ubuntu20.04_amd64.deb -O "${TEMP_PRINCE}"
+                  sudo apt-get install gdebi -y
+                  wget https://www.princexml.com/download/prince_15.3-1_ubuntu22.04_amd64.deb -O "${TEMP_PRINCE}"
                   sudo gdebi "${TEMP_PRINCE}" --n
             - name: Checkout code
               uses: actions/checkout@v3

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -25,7 +25,7 @@ jobs:
             - name: Install Prince
               run: |
                   TEMP_PRINCE="$(mktemp)"
-                  sudo apt-get install gdebi -y
+                  sudo apt-get install gdebi lintian=2.62.0ubuntu2.4 -y
                   wget https://www.princexml.com/download/prince_15.3-1_ubuntu20.04_amd64.deb -O "${TEMP_PRINCE}"
                   sudo gdebi "${TEMP_PRINCE}" --n
             - name: Checkout code

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -25,7 +25,7 @@ jobs:
             - name: Install Prince
               run: |
                   TEMP_PRINCE="$(mktemp)"
-                  sudo apt-get install gdebi lintian=2.62.0ubuntu2.4 -y
+                  sudo apt-get install gdebi lintian -y
                   wget https://www.princexml.com/download/prince_15.3-1_ubuntu20.04_amd64.deb -O "${TEMP_PRINCE}"
                   sudo gdebi "${TEMP_PRINCE}" --n
             - name: Checkout code

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -25,7 +25,7 @@ jobs:
             - name: Install Prince
               run: |
                   TEMP_PRINCE="$(mktemp)"
-                  sudo apt-get install gdebi -y
+                  sudo apt-get install gdebi -y --fix-missing
                   wget https://www.princexml.com/download/prince_15.3-1_ubuntu22.04_amd64.deb -O "${TEMP_PRINCE}"
                   sudo gdebi "${TEMP_PRINCE}" --n
             - name: Checkout code

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -24,9 +24,8 @@ jobs:
                   port: 5432
             - name: Install Prince
               run: |
-                  sudo apt-get update
                   TEMP_PRINCE="$(mktemp)"
-                  sudo apt-get install gdebi -y
+                  sudo apt-get update; sudo apt-get install gdebi -y
                   wget https://www.princexml.com/download/prince_15.3-1_ubuntu22.04_amd64.deb -O "${TEMP_PRINCE}"
                   sudo gdebi "${TEMP_PRINCE}" --n
             - name: Checkout code

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -24,8 +24,9 @@ jobs:
                   port: 5432
             - name: Install Prince
               run: |
+                  sudo apt-get update
                   TEMP_PRINCE="$(mktemp)"
-                  sudo apt-get install gdebi -y --fix-missing
+                  sudo apt-get install gdebi -y
                   wget https://www.princexml.com/download/prince_15.3-1_ubuntu22.04_amd64.deb -O "${TEMP_PRINCE}"
                   sudo gdebi "${TEMP_PRINCE}" --n
             - name: Checkout code

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -26,7 +26,7 @@ jobs:
               run: |
                   TEMP_PRINCE="$(mktemp)"
                   sudo apt-get install gdebi -y
-                  wget https://www.princexml.com/download/prince_15-1_ubuntu20.04_amd64.deb -O "${TEMP_PRINCE}"
+                  wget https://www.princexml.com/download/prince_15.3-1_ubuntu20.04_amd64.deb -O "${TEMP_PRINCE}"
                   sudo gdebi "${TEMP_PRINCE}" --n
             - name: Checkout code
               uses: actions/checkout@v3


### PR DESCRIPTION
I investigated why our Github testing workflow was [failing since yesterday](https://github.com/art-institute-of-chicago/artic.edu/actions/runs/9180522482) and discovered that we need to update the local `apt` cache before installing `gdebi`. In addition to this change, I also updated Prince to the [latest version](https://www.princexml.com/download/15/#ubuntu), as well as the corresponding Ubuntu [version](https://www.releases.ubuntu.com/jammy/).