### PR TITLE
Updates sitemap generator with new visit route

### DIFF
--- a/app/Console/Commands/GenerateSitemap.php
+++ b/app/Console/Commands/GenerateSitemap.php
@@ -67,7 +67,7 @@ class GenerateSitemap extends Command
     private function addHardcodedPages(&$sitemap)
     {
         $this->addRoute($sitemap, 'home', 1.0);
-        $this->addRoute($sitemap, 'visit', 1.0);
+        $this->addUrl($sitemap, route('pages.slug', ['slug' => 'visit']), 1.0);
         $this->addRoute($sitemap, 'events', 0.9);
         $this->addRoute($sitemap, 'collection', 0.9);
         $this->addRoute($sitemap, 'articles_publications');


### PR DESCRIPTION
This prevents the website deploy from this failure:
```
TASK [apps/website : php artisan sitemap:generate] ******************************************************************
FAILED - RETRYING: [172.20.20.142]: php artisan sitemap:generate (3 retries left).
FAILED - RETRYING: [172.20.20.142]: php artisan sitemap:generate (2 retries left).
FAILED - RETRYING: [172.20.20.142]: php artisan sitemap:generate (1 retries left).
fatal: [172.20.20.142]: FAILED! => changed=true 
  attempts: 3
  cmd:
  - php
  - artisan
  - sitemap:generate
  - --quiet
  delta: '0:00:00.628498'
  end: '2024-05-28 17:55:31.810858'
  msg: non-zero return code
  rc: 1
  start: '2024-05-28 17:55:31.182360'
  stderr: ''
  stderr_lines: <omitted>
  stdout: |2-
  
    In UrlGenerator.php line 479:
  
      Route [visit] not defined.
  stdout_lines: <omitted>
```