### PR TITLE
Fix sorting by "Is DSC stub?" column

### DIFF
--- a/app/Http/Controllers/Admin/DigitalPublicationController.php
+++ b/app/Http/Controllers/Admin/DigitalPublicationController.php
@@ -16,7 +16,7 @@ class DigitalPublicationController extends ModuleController
         ],
         'type' => [
             'title' => 'Is DSC stub?',
-            'field' => 'isDscStub',
+            'field' => 'is_dsc_stub',
             'sort' => true,
             'present' => true,
         ],


### PR DESCRIPTION
One line fix for sorting by "Is DSC stub?" column on Digital Publications index page