### PR TITLE
Update references to digipub article types

### DIFF
--- a/resources/views/site/digitalPublicationArticleDetail.blade.php
+++ b/resources/views/site/digitalPublicationArticleDetail.blade.php
@@ -1,3 +1,7 @@
+@php
+    use App\Enums\DigitalPublicationArticleType;
+@endphp
+
 @extends('layouts.app')
 
 @section('content')
@@ -16,7 +20,7 @@
         @endcomponent
     </div>
 
-    @if ($item->type == \App\Enums\DigitalPublicationArticleType::Contributions)
+    @if ($item->type == DigitalPublicationArticleType::Contributions)
         @component('components.molecules._m-article-header----journal-article')
             @slot('title', $item->present()->title)
             @slot('title_display', $item->present()->title_display)
@@ -45,8 +49,8 @@
     </div>
     @endif
 
-    <div class="o-article__body o-blocks o-blocks--with-sidebar {{ $item->type != \App\Enums\DigitalPublicationArticleType::Contributions ? "o-article__body--no-top-border" : "" }}">
-        @if ($item->type == \App\Enums\DigitalPublicationArticleType::Contributions)
+    <div class="o-article__body o-blocks o-blocks--with-sidebar {{ $item->type != DigitalPublicationArticleType::Contributions ? "o-article__body--no-top-border" : "" }}">
+        @if ($item->type == DigitalPublicationArticleType::Contributions)
             @if ($item->showAuthorsWithLinks())
                 @component('components.blocks._text')
                     @slot('font', 'f-tag-2')
@@ -58,7 +62,7 @@
         @endif
 
         @php
-        if ($item->type == \App\Enums\DigitalPublicationArticleType::Contributions) {
+        if ($item->type == DigitalPublicationArticleType::Contributions) {
             global $_collectedReferences;
             $_collectedReferences = [];
 

--- a/resources/views/site/digitalPublicationArticleDetail.blade.php
+++ b/resources/views/site/digitalPublicationArticleDetail.blade.php
@@ -16,7 +16,7 @@
         @endcomponent
     </div>
 
-    @if ($item->type == \App\Models\DigitalPublicationArticle::TEXT)
+    @if ($item->type == \App\Enums\DigitalPublicationArticleType::Contributions)
         @component('components.molecules._m-article-header----journal-article')
             @slot('title', $item->present()->title)
             @slot('title_display', $item->present()->title_display)
@@ -45,8 +45,8 @@
     </div>
     @endif
 
-    <div class="o-article__body o-blocks o-blocks--with-sidebar {{ $item->type != \App\Models\DigitalPublicationArticle::TEXT ? "o-article__body--no-top-border" : "" }}">
-        @if ($item->type == \App\Models\DigitalPublicationArticle::TEXT)
+    <div class="o-article__body o-blocks o-blocks--with-sidebar {{ $item->type != \App\Enums\DigitalPublicationArticleType::Contributions ? "o-article__body--no-top-border" : "" }}">
+        @if ($item->type == \App\Enums\DigitalPublicationArticleType::Contributions)
             @if ($item->showAuthorsWithLinks())
                 @component('components.blocks._text')
                     @slot('font', 'f-tag-2')
@@ -58,7 +58,7 @@
         @endif
 
         @php
-        if ($item->type == \App\Models\DigitalPublicationArticle::TEXT) {
+        if ($item->type == \App\Enums\DigitalPublicationArticleType::Contributions) {
             global $_collectedReferences;
             $_collectedReferences = [];
 

--- a/resources/views/site/digitalPublicationDetail.blade.php
+++ b/resources/views/site/digitalPublicationDetail.blade.php
@@ -1,5 +1,5 @@
 @php
-    use App\Models\DigitalPublicationArticle;
+    use App\Enums\DigitalPublicationArticleType;
 @endphp
 
 @extends('layouts.app')
@@ -41,11 +41,11 @@
             </div>
         @endif
 
-        @if ($item->present()->hasArticles(DigitalPublicationArticle::TEXT))
+        @if ($item->present()->hasArticles(DigitalPublicationArticleType::Contributions->value))
             @component('components.molecules._m-title-bar', [
                 'variation' => 'm-title-bar--compact m-title-bar--light',
             ])
-                {{ DigitalPublicationArticle::$types[DigitalPublicationArticle::TEXT] }}
+                {{ DigitalPublicationArticleType::Contributions->name }}
             @endcomponent
 
             @component('components.organisms._o-grid-listing')
@@ -55,7 +55,7 @@
                 @slot('cols_medium','2')
                 @slot('cols_large','2')
                 @slot('cols_xlarge','2')
-                @foreach ($item->present()->getArticles(DigitalPublicationArticle::TEXT) as $article)
+                @foreach ($item->present()->getArticles(DigitalPublicationArticleType::Contributions->value) as $article)
                     @component('components.molecules._m-listing----publication')
                         @slot('variation', 'm-listing--journal')
                         @slot('href', $article->present()->getArticleUrl($item))
@@ -82,17 +82,17 @@
             @endcomponent
         @endif
 
-        @if ($item->present()->hasArticles(DigitalPublicationArticle::WORK))
+        @if ($item->present()->hasArticles(DigitalPublicationArticleType::Works->value))
             @component('components.molecules._m-title-bar', [
                 'variation' => 'm-title-bar--compact m-title-bar--light',
             ])
-                {{ DigitalPublicationArticle::$types[DigitalPublicationArticle::WORK] }}
+                {{ DigitalPublicationArticleType::Works->name }}
             @endcomponent
 
             @component('components.organisms._o-grid-listing')
                 @slot('variation', 'o-grid-listing--journal')
 
-                @foreach ($item->present()->getArticles(DigitalPublicationArticle::WORK) as $article)
+                @foreach ($item->present()->getArticles(DigitalPublicationArticleType::Works->value) as $article)
                     @component('components.molecules._m-listing----publication')
                         @slot('variation', 'm-listing--work')
                         @slot('href', $article->present()->getArticleUrl($item))


### PR DESCRIPTION
This change updates the references to digital publication article types in the site templates from the constants/static array to the enum.