### PR TITLE
DigiPub articles link

### DIFF
--- a/app/Http/Controllers/Admin/DigitalPublicationController.php
+++ b/app/Http/Controllers/Admin/DigitalPublicationController.php
@@ -20,6 +20,10 @@ class DigitalPublicationController extends ModuleController
             'sort' => true,
             'present' => true,
         ],
+        'articles' => [
+            'title' => 'Articles',
+            'nested' => 'articles',
+        ],
     ];
 
     protected function formData($request)

--- a/resources/views/admin/digitalPublications/form.blade.php
+++ b/resources/views/admin/digitalPublications/form.blade.php
@@ -1,32 +1,5 @@
 @extends('twill::layouts.form')
 
-@section('sideFieldsets')
-    @formFieldset([
-        'id' => 'digital-publication-links',
-        'title' => 'Links',
-    ])
-        {{-- TODO: add links to groupings when the index page is created --}}
-        <ul>
-            <li>
-                <a>About</a>
-            </li>
-            <li>
-                <a>Contributions</a>
-            </li>
-            <li>
-                <a>Works</a>
-            </li>
-            <li>
-                <a>etc</a>
-            </li>
-            <li class="see-all">
-                <a href="{{ url('/collection/articles_publications/digitalPublications/' . $item->id . '/articles') }}">
-                    See all
-                </a>
-            </li>
-        </ul>
-    @endformFieldset
-@stop
 @push('extra_css')
     <style>
         #digital-publication-links li {

--- a/resources/views/admin/digitalPublications/form.blade.php
+++ b/resources/views/admin/digitalPublications/form.blade.php
@@ -2,16 +2,20 @@
 
 @push('extra_css')
     <style>
-        #digital-publication-links li {
-            margin-top: 1em;
-        }
-        #digital-publication-links li.see-all {
+        #content .articles-index-link {
             font-weight: bold;
+            margin-top: 1em;
         }
     </style>
 @endPush
 
 @section('contentFields')
+    <div class="articles-index-link">
+        <a href="{{ route('admin.collection.articles_publications.digitalPublications.articles.index', [$item->id]) }}">
+            {{ $item->articles->count() }} articles
+        </a>
+    </div>
+
     @formField('wysiwyg', [
         'name' => 'header_title_display',
         'label' => 'Title lockup for header',


### PR DESCRIPTION
This change removes the placeholders for the groupings links from the digital publication form. It also adds back the link to the articles index to the Content fieldset, as well as adding it to the digital publication index table.