### PR TITLE
Fix issue with `type` field

### DIFF
--- a/app/Repositories/DigitalPublicationArticleRepository.php
+++ b/app/Repositories/DigitalPublicationArticleRepository.php
@@ -31,6 +31,24 @@ class DigitalPublicationArticleRepository extends ModuleRepository
             ->mapWithKeys(fn ($type) => [$type->value => $type->name]);
     }
 
+    public function getFormFields($object)
+    {
+        $fields = parent::getFormFields($object);
+        return ['article_type' => $fields['type']];
+    }
+
+    public function prepareFieldsBeforeCreate($fields)
+    {
+        $fields['type'] = $fields['article_type'];
+        return parent::prepareFieldsBeforeCreate($fields);
+    }
+
+    public function beforeSave($object, $fields)
+    {
+        parent::beforeSave($object, $fields);
+        $object->type = $fields['article_type'];
+    }
+
     public function afterSave($object, $fields)
     {
         parent::afterSave($object, $fields);

--- a/resources/views/admin/digitalPublications/articles/create.blade.php
+++ b/resources/views/admin/digitalPublications/articles/create.blade.php
@@ -1,7 +1,7 @@
 @include('twill::partials.create')
 
 @formField('select', [
-    'name' => 'type',
+    'name' => 'article_type',
     'label' => 'Type',
     'placeholder' => 'Select a type',
     'options' => $types,


### PR DESCRIPTION
The `type` property needs to be transformed to `article_type` and vice versa when creating/saving digital publication articles.