### PR TITLE
Fix article type select and conditional field

### DIFF
--- a/app/Models/Behaviors/LintsAttributes.php
+++ b/app/Models/Behaviors/LintsAttributes.php
@@ -6,6 +6,9 @@ trait LintsAttributes
 {
     protected function lintValue($value)
     {
+        if ($value instanceof \UnitEnum) {
+            return $value;
+        }
         if (is_object($value)) {
             foreach ($value as $key => $subvalue) {
                 $value->{$key} = $this->lintValue($subvalue);

--- a/app/Repositories/DigitalPublicationArticleRepository.php
+++ b/app/Repositories/DigitalPublicationArticleRepository.php
@@ -31,24 +31,6 @@ class DigitalPublicationArticleRepository extends ModuleRepository
             ->mapWithKeys(fn ($type) => [$type->value => $type->name]);
     }
 
-    public function getFormFields($object)
-    {
-        $fields = parent::getFormFields($object);
-        return ['article_type' => $fields['type']];
-    }
-
-    public function prepareFieldsBeforeCreate($fields)
-    {
-        $fields['type'] = $fields['article_type'];
-        return parent::prepareFieldsBeforeCreate($fields);
-    }
-
-    public function beforeSave($object, $fields)
-    {
-        parent::beforeSave($object, $fields);
-        $object->type = $fields['article_type'];
-    }
-
     public function afterSave($object, $fields)
     {
         parent::afterSave($object, $fields);

--- a/resources/views/admin/digitalPublications/articles/form.blade.php
+++ b/resources/views/admin/digitalPublications/articles/form.blade.php
@@ -32,7 +32,7 @@
     ])
 
     @formField('select', [
-        'name' => 'article_type', // Cannot be named `type`
+        'name' => 'type',
         'label' => 'Type',
         'placeholder' => 'Select a type',
         'default' => 'text',
@@ -121,7 +121,7 @@
 
 @section('fieldsets')
     @formConnectedFields([
-        'fieldName' => 'article_type',
+        'fieldName' => 'type',
         'fieldValues' => 'grouping',
         'renderForBlocks' => false,
     ])


### PR DESCRIPTION
It turns out that the reason the digipub article's `type` field wasn't working isn't because it was named `type`, but because the `LintsAttributes` behavior was treating it as a regular object (which enums are, but they have read-only properties) and choking, disrupting the page render. So I added a check for enums with an early return. Enums values don't need to be linted because they are not user input; they are defined in code.

This also apparently addresses the missing article link:
<img width="614" alt="Screenshot 2024-06-13 at 3 21 18 PM" src="https://github.com/art-institute-of-chicago/artic.edu/assets/2098951/5640ad8d-8a8e-438e-b02e-e3d480f89f87">
