### PR TITLE
Update `migrate:osci-publication` to use migration file from `osci-migration`

### DIFF
--- a/app/Console/Commands/MigrateOSCIPublication.php
+++ b/app/Console/Commands/MigrateOSCIPublication.php
@@ -4,21 +4,21 @@ namespace App\Console\Commands;
 
 use Illuminate\Console\Command;
 
-class MigrateOSCIPublicationMedia extends Command
+class MigrateOSCIPublication extends Command
 {
     /**
      * The name and signature of the console command.
      *
      * @var string
      */
-    protected $signature = 'migrate:osci-media';
+    protected $signature = 'migrate:osci-publication';
 
     /**
      * The console command description.
      *
      * @var string
      */
-    protected $description = 'Migrate all OSCI publications\' IIP and 360º media from OSCI servers to S3';
+    protected $description = 'Migrate all OSCI publications from a migration file to website DigitalPublications';
 
     protected $publications = [
         'albright',
@@ -47,7 +47,7 @@ class MigrateOSCIPublicationMedia extends Command
     public function handle()
     {
         foreach ($this->publications as $pub) {
-            $this->call('migrate:osci-media-one', ['id' => $pub]);
+            $this->call('migrate:osci-publication-one', ['id' => $pub]);
         }
     }
 }

--- a/app/Console/Commands/MigrateOSCIPublicationMedia.php
+++ b/app/Console/Commands/MigrateOSCIPublicationMedia.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Imagick;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Str;
+
+$PTIF_LAYER_MAX = 10000;
+
+class MigrateOSCIPublicationMedia extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'migrate:osci-media {id : Publication ID} {--move-assets}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Migrate an OSCI publications\' IIP and 360º media from OSCI servers to S3';
+
+    /**
+     * Execute the console command.
+     *
+     * @return int
+     */
+    public function handle()
+    {
+        $pubId = $this->argument('id');
+
+        # TODO: Query 360s too
+        $assetsQuery = <<<EOT
+        SELECT DISTINCT json_extract(layers.value,'$._image_ident') AS image_ident
+        FROM figure_layers,
+            json_each(figure_layers.data,'$.layers') AS layers 
+        WHERE json_extract(layers.value,'$._type')='iip'
+                AND figure_layers.package=:pubId
+        ORDER BY json_extract(layers.value,'$._height') ASC
+EOT;
+
+        $assets = DB::connection('osci_migration')->select($assetsQuery, ['pubId' => $pubId]);
+
+        foreach ($assets as $asset) {
+            // TODO: Check the asset type and handle 360 spins differently
+            $key = trim($asset->image_ident, '/');
+            $asset_key = preg_replace('/^\/?osci\//', '', $asset->image_ident);
+            $jpg_key = preg_replace('/\.ptif$/', '.jpg', $key);
+
+            if (!Storage::disk('osci_s3')->fileExists($asset_key)) {
+                echo "OSCI_S3_BUCKET did not contain {$asset_key}!\n";
+                continue;
+            }
+
+            if (Storage::disk('osci_s3')->fileExists($jpg_key)) {
+                echo "OSCI_S3_BUCKET already contains {$jpg_key}, skipping this asset\n";
+                continue;
+            }
+
+            echo "Compressing {$asset_key}\n";
+
+            $content = Storage::disk('osci_s3')->get($asset_key);
+
+            $image = new Imagick();
+            $image->readImageBlob($content);
+
+            // Iterate zoom layers to find a 10k-pixels-a-side page geometry
+            while ($image->hasPreviousImage()) {
+                $size = $image->getImagePage();
+
+                if ($size['height'] > 10000 && $size['width'] > 10000) {
+                    $image->nextImage();
+                    break;
+                }
+                $image->previousImage();
+            }
+
+            $image->setImageFormat('jpeg');
+            $compressed = $image->getImageBlob();
+
+            $res = Storage::disk('osci_s3')->put($jpg_key, $compressed);
+
+            if (!$res) {
+                echo "There was an error uploading the compressed file to {$jpg_key}\n";
+                continue;
+            }
+
+            echo "Uploaded {$jpg_key}\n";
+        }
+    }
+}

--- a/app/Console/Commands/MigrateOSCIPublicationMediaOne.php
+++ b/app/Console/Commands/MigrateOSCIPublicationMediaOne.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Imagick;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Str;
+
+$PTIF_LAYER_MAX = 10000;
+
+class MigrateOSCIPublicationMediaOne extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'migrate:osci-media-one {id : Publication ID} {--move-assets}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Migrate an OSCI publications\' IIP and 360º media from OSCI servers to S3';
+
+    /**
+     * Execute the console command.
+     *
+     * @return int
+     */
+    public function handle()
+    {
+        $pubId = $this->argument('id');
+        $this->comment('Starting ' . $pubId . '...');
+
+        # TODO: Query 360s too
+        $assetsQuery = <<<EOT
+        SELECT DISTINCT json_extract(layers.value,'$._image_ident') AS image_ident
+        FROM figure_layers,
+            json_each(figure_layers.data,'$.layers') AS layers
+        WHERE json_extract(layers.value,'$._type')='iip'
+                AND figure_layers.package=:pubId
+        ORDER BY json_extract(layers.value,'$._height') ASC
+EOT;
+
+        $assets = DB::connection('osci_migration')->select($assetsQuery, ['pubId' => $pubId]);
+
+        foreach ($assets as $asset) {
+            // TODO: Check the asset type and handle 360 spins differently
+            $key = trim($asset->image_ident, '/');
+            $asset_key = preg_replace('/^\/?osci\//', '', $asset->image_ident);
+            $jpg_key = preg_replace('/\.ptif$/', '.jpg', $key);
+
+            if (!Storage::disk('osci_s3')->fileExists($asset_key)) {
+                $this->info("OSCI_S3_BUCKET did not contain {$asset_key}!");
+                continue;
+            }
+
+            if (Storage::disk('osci_s3')->fileExists($jpg_key)) {
+                $this->info("OSCI_S3_BUCKET already contains {$jpg_key}, skipping this asset");
+                continue;
+            }
+
+            $this->info("Compressing {$asset_key}");
+
+            $content = Storage::disk('osci_s3')->get($asset_key);
+
+            $image = new Imagick();
+            $image->readImageBlob($content);
+
+            // Iterate zoom layers to find a 10k-pixels-a-side page geometry
+            while ($image->hasPreviousImage()) {
+                $size = $image->getImagePage();
+
+                if ($size['height'] > 10000 && $size['width'] > 10000) {
+                    $image->nextImage();
+                    break;
+                }
+                $image->previousImage();
+            }
+
+            $image->setImageFormat('jpeg');
+            $compressed = $image->getImageBlob();
+
+            $res = Storage::disk('osci_s3')->put($jpg_key, $compressed);
+
+            if (!$res) {
+                $this->info("There was an error uploading the compressed file to {$jpg_key}");
+                continue;
+            }
+
+            echo "Uploaded {$jpg_key}\n";
+        }
+        $this->comment('...' . $pubId . ' done!');
+    }
+}

--- a/app/Console/Commands/MigrateOSCIPublicationMediaOne.php
+++ b/app/Console/Commands/MigrateOSCIPublicationMediaOne.php
@@ -6,8 +6,6 @@ use Imagick;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Storage;
-use Illuminate\Support\Arr;
-use Illuminate\Support\Str;
 
 $PTIF_LAYER_MAX = 10000;
 

--- a/app/Console/Commands/MigrateOSCIPublicationMediaOne.php
+++ b/app/Console/Commands/MigrateOSCIPublicationMediaOne.php
@@ -16,7 +16,7 @@ class MigrateOSCIPublicationMediaOne extends Command
      *
      * @var string
      */
-    protected $signature = 'migrate:osci-media-one {id : Publication ID} {--move-assets}';
+    protected $signature = 'migrate:osci-media-one {id : Publication ID}';
 
     /**
      * The console command description.

--- a/app/Console/Commands/MigrateOSCIPublicationOne.php
+++ b/app/Console/Commands/MigrateOSCIPublicationOne.php
@@ -7,7 +7,6 @@ use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
-use App\Repositories\Api\PublicationRepository;
 use App\Models\DigitalPublication;
 use App\Models\DigitalPublicationArticle;
 use App\Models\Vendor\Block;

--- a/app/Console/Commands/MigrateOSCIPublicationOne.php
+++ b/app/Console/Commands/MigrateOSCIPublicationOne.php
@@ -116,15 +116,20 @@ class MigrateOSCIPublicationOne extends Command
 
             $blk = $blocksResult->fetchArray();
 
+            $order = 0;
+
             while ($blk) {
 
                 $block = new Block();
                 $block->blockable_id = $webArticle->id;
                 $block->blockable_type = 'App\Models\DigitalPublicationArticle';
 
-                $block->position = $blk['position'];
+                $block->position = $order;
+
+                // TODO: Adapt Trevin's spec image code here
                 if ($blk['type'] == 'figure') {
                     
+                    // $figText = '<span>'.$blk['figure_url'].'</span>';
                     $figText = '<figure><img src="'. $blk['figure_url'] . '" alt /><figcaption>'.$blk['figure_capt'].'</figcaption></figure>';
 
                     $block->content = [ 'paragraph' => $figText ];
@@ -138,6 +143,7 @@ class MigrateOSCIPublicationOne extends Command
                 $webArticle->blocks()->save($block);
 
                 $blk = $blocksResult->fetchArray();
+                $order += 1;
             }
 
             $webPub->articles()->save($webArticle);

--- a/app/Console/Commands/MigrateOSCIPublicationOne.php
+++ b/app/Console/Commands/MigrateOSCIPublicationOne.php
@@ -221,7 +221,6 @@ class MigrateOSCIPublicationOne extends Command
         $layerBlock->parent_id = $block->id;
 
         // Configure this as an image or overlay and set position
-        // TODO: Check the extension as PNGs appear to be overlays as well
 
         if ($layer_data['type'] == 'svg' || pathinfo($layer_data['static_url'], PATHINFO_EXTENSION) === 'png') {
             $layerBlock->child_key = 'layered_image_viewer_overlay';
@@ -304,36 +303,39 @@ class MigrateOSCIPublicationOne extends Command
         // Type-sense the figure and apply the appropriate CMS block type -- each just returns early
         switch (true) {
             // Non-video embeds (HTML, mostly) become media_embed
-            case ($figure->figure_type === 'html_figure' && !isset($figure->html_content_src)):
+            case $figure->figure_type === 'html_figure' 
+                    && !isset($figure->html_content_src):
                 $this->configureHTMLFigure($block, $figure);
                 return;
 
             // HTML embeds with a src are videos
-            case ($figure->figure_type === 'html_figure' && isset($figure->html_content_src)):
+            case $figure->figure_type === 'html_figure' 
+                    && isset($figure->html_content_src):
                 $this->configureVideoFigure($block, $figure);
                 return;
 
             // OSCI's layered_image with only one layer should just be an image
-            case ($figure->figure_type === 'layered_image' && count($layers) === 1):
+            case $figure->figure_type === 'layered_image' 
+                    && count($layers) === 1:
                 $this->configureImageFigure($block, $figure, $layers);
                 return;
 
             // Layered images are just that
-            case ($figure->figure_type === 'layered_image'):
+            case $figure->figure_type === 'layered_image':
                 $this->configureLayeredImageFigure($block, $figure, $layers);
                 return;
 
             // IIP Asset images are also images
-            case ($figure->figure_type === 'iip_asset'):
+            case $figure->figure_type === 'iip_asset':
                 $this->configureImageFigure($block, $figure, $layers);
                 return;
 
-            case ($figure->figure_type === '360_slider'):
+            case $figure->figure_type === '360_slider':
                 $this->configure360EmbedFigure($block, $figure);
                 return;
 
             // RTI_Viewers will need other handling, so leave a placeholder..
-            case ($figure->figure_type === 'rti_viewer'):
+            case $figure->figure_type === 'rti_viewer':
                 // TODO: insert reader_url, figure # for this text + figure
                 $block->type = 'video';
                 $block->content = [

--- a/app/Console/Commands/MigrateOSCIPublicationOne.php
+++ b/app/Console/Commands/MigrateOSCIPublicationOne.php
@@ -53,6 +53,9 @@ class MigrateOSCIPublicationOne extends Command
 
         $texts = DB::connection('osci_migration')->select("SELECT coalesce(json_extract(data,'$._title'),'FIXME') as title,text_id FROM texts WHERE package=:pubId and text_id NOT LIKE '%ncxtoc%'", ['pubId' => $pubId]);
 
+        // Initialize the left value
+        $lft = 1;
+
         foreach ($texts as $text) {
 
             $webArticle = new DigitalPublicationArticle();
@@ -63,6 +66,8 @@ class MigrateOSCIPublicationOne extends Command
             $webArticle->date = date('M j, Y');
             $webArticle->updated_at = date('M j, Y');
             $webArticle->created_at = date('M j, Y');
+            $webArticle->_lft = $lft++;
+            $webArticle->_rgt = $lft++;
 
             // TODO: Join toc position via json_tree against toc data
             $webArticle->position = 0;

--- a/app/Console/Commands/MigrateOSCIPublicationOne.php
+++ b/app/Console/Commands/MigrateOSCIPublicationOne.php
@@ -44,9 +44,10 @@ class MigrateOSCIPublicationOne extends Command
     {
         $imageUrl;
         switch ($imageData["type"]) {
-            case "iip":
-                $imageUrl = $imageData["image_url_stem"] . '?fif=' . $imageData["image_ident"] . '&cvt=jpeg' ;
-                break;
+            // TODO: Use s3 URLs instead
+            // case "iip":
+            //     $imageUrl = $imageData["image_url_stem"] . '?fif=' . $imageData["image_ident"] . '&cvt=jpeg' ;
+            //     break;
 
             case "image":
                 $imageUrl = $imageData["static_url"];

--- a/app/Console/Commands/MigrateOSCIPublicationOne.php
+++ b/app/Console/Commands/MigrateOSCIPublicationOne.php
@@ -59,7 +59,6 @@ class MigrateOSCIPublicationOne extends Command
             default:
                 $imageUrl = $fallback_url;
                 break;
-
         }
 
         // TODO: Load JPEG-converted PTIFF URL from this from db's `assets` table
@@ -87,7 +86,7 @@ class MigrateOSCIPublicationOne extends Command
 
         try {
             $imageContent = file_get_contents($imageUrl, false, $ctx);
-        } catch (Exception $e) {
+        } catch (ErrorException $e) {
             var_dump($e);
             exit(1);
         }
@@ -96,7 +95,7 @@ class MigrateOSCIPublicationOne extends Command
             $width = $imageData['width'];
             $height = $imageData['height'];
         } else {
-            [$width, $height] = getimagesizefromstring($imageContent);        
+            [$width, $height] = getimagesizefromstring($imageContent);
         }
 
         Storage::disk('s3')->put($imageName, $imageContent);
@@ -219,7 +218,7 @@ class MigrateOSCIPublicationOne extends Command
                     $layerBlock->parent_id = $block->id;
 
                     // Configure this as an image or overlay and set position
-                    if($imageData['type'] == 'svg') {
+                    if ($imageData['type'] == 'svg') {
                         $layerBlock->child_key = 'layered_image_viewer_overlay';
                         $layerBlock->type = 'layered_image_viewer_overlay';
                     } else {

--- a/app/Console/Commands/MigrateOSCIPublicationOne.php
+++ b/app/Console/Commands/MigrateOSCIPublicationOne.php
@@ -303,19 +303,19 @@ class MigrateOSCIPublicationOne extends Command
         // Type-sense the figure and apply the appropriate CMS block type -- each just returns early
         switch (true) {
             // Non-video embeds (HTML, mostly) become media_embed
-            case $figure->figure_type === 'html_figure' 
+            case $figure->figure_type === 'html_figure'
                     && !isset($figure->html_content_src):
                 $this->configureHTMLFigure($block, $figure);
                 return;
 
             // HTML embeds with a src are videos
-            case $figure->figure_type === 'html_figure' 
+            case $figure->figure_type === 'html_figure'
                     && isset($figure->html_content_src):
                 $this->configureVideoFigure($block, $figure);
                 return;
 
             // OSCI's layered_image with only one layer should just be an image
-            case $figure->figure_type === 'layered_image' 
+            case $figure->figure_type === 'layered_image'
                     && count($layers) === 1:
                 $this->configureImageFigure($block, $figure, $layers);
                 return;

--- a/app/Console/Commands/MigrateOSCIPublicationOne.php
+++ b/app/Console/Commands/MigrateOSCIPublicationOne.php
@@ -48,9 +48,10 @@ class MigrateOSCIPublicationOne extends Command
         switch ($imageData["type"]) {
             case "iip":
                 $img_ident = trim($imageData["image_ident"], '/');
-                $img_key = preg_replace('/\.ptif$/', '.jpg', $img_ident);
 
-                $imageUrl = 's3://osci-web-images.artic.edu/{$img_key}';
+                $bucket = config('aic.osci_s3_bucket');
+                $img_key = preg_replace('/\.ptif$/', '.jpg', $img_ident);
+                $imageUrl = "s3://{$bucket}/{$img_key}";
 
                 if (Storage::disk('osci_s3')->fileExists($img_key)) {
                     $imageContent = Storage::disk('osci_s3')->get($img_key);

--- a/app/Console/Commands/MigrateOSCIPublicationOne.php
+++ b/app/Console/Commands/MigrateOSCIPublicationOne.php
@@ -20,7 +20,7 @@ class MigrateOSCIPublicationOne extends Command
      *
      * @var string
      */
-    protected $signature = 'migrate:osci-publication {id : Publication ID}';
+    protected $signature = 'migrate:osci-publication-one {id : Publication ID}';
 
     /**
      * The console command description.
@@ -94,7 +94,7 @@ class MigrateOSCIPublicationOne extends Command
         $retries = 0;
         while (!$imageContent && $retries < 5) {
             try {
-                $imageContent = file_get_contents($imageUrl, false, $http_ctx);                
+                $imageContent = file_get_contents($imageUrl, false, $http_ctx);
             } catch (ErrorException $e) {
                 echo "Caught error {$e} fetching {$imageUrl}, retrying.\n";
                 pass;
@@ -133,7 +133,7 @@ class MigrateOSCIPublicationOne extends Command
         $media->save();
 
         return $media;
-    }   
+    }
 
     private function configureImageFigure($block, $data, $layers)
     {
@@ -187,7 +187,7 @@ class MigrateOSCIPublicationOne extends Command
         $block->save();
     }
 
-    private function configureHTMLFigure($block, $data) 
+    private function configureHTMLFigure($block, $data)
     {
         $block->type = 'media_embed';
         $block->content = [
@@ -307,7 +307,7 @@ class MigrateOSCIPublicationOne extends Command
                 $this->configureVideoFigure($block, $figure);
                 return;
 
-            // OSCI's layered_image with only one layer should just be an image            
+            // OSCI's layered_image with only one layer should just be an image
             case ($figure->figure_type === 'layered_image' && count($layers) === 1):
                 $this->configureImageFigure($block, $figure, $layers);
                 return;

--- a/app/Console/Commands/MigrateOSCIPublicationOne.php
+++ b/app/Console/Commands/MigrateOSCIPublicationOne.php
@@ -40,13 +40,13 @@ class MigrateOSCIPublicationOne extends Command
                 // TODO: if $figure->html_content_src set embed_type => url and url => html_content_src
 
                 $block->type = 'media_embed';
-                $block->content = json_encode([
+                $block->content = [
                     "size" => "m",
                     "embed_type" => "html",
                     "embed_code" => $figure->html_content,
                     "embed_height" => "400px",
                     "disable_placeholder" => true
-                ]);
+                ];
 
                 $block->save();
 
@@ -57,7 +57,7 @@ class MigrateOSCIPublicationOne extends Command
             case 'iip_asset':
 
                 $block->type = 'image';
-                $block->content = json_encode([
+                $block->content = [
                   "is_modal" => false,
                   "is_zoomable" => false,
                   "size" => "m",
@@ -65,7 +65,7 @@ class MigrateOSCIPublicationOne extends Command
                   "use_alt_background" => true,
                   "image_link" => null,
                   "caption" => $figure->caption_html
-                ]);
+                ];
 
                 // Media uploads and relations
                 $imagePath = 'test.jpeg';
@@ -83,7 +83,7 @@ class MigrateOSCIPublicationOne extends Command
 
                 $mediaId = $media->id;
 
-                $block->medias()->attach($mediaId, ['role' => 'default','metadatas' => '{"caption":null,"altText":null,"video":null}']);
+                $block->medias()->attach($mediaId, ['role' => 'default','crop' => 'default', 'metadatas' => '{"caption":null,"altText":null,"video":null}']);
 
                 $block->save();
 

--- a/app/Console/Commands/MigrateOSCIPublicationOne.php
+++ b/app/Console/Commands/MigrateOSCIPublicationOne.php
@@ -378,11 +378,17 @@ class MigrateOSCIPublicationOne extends Command
         $pubs = DB::connection('osci_migration')->select("SELECT json_extract(publications.data,'$._title') as title FROM publications LEFT JOIN tocs ON tocs.package=publications.pub_id WHERE pub_id=:id", ['id' => $pubId]);
         $pub = Arr::first($pubs);
 
+        if (!$pub) {
+            $this->error('No publication with the ID: ' . $pubId);
+            return;
+        }
+
         $webPub = new DigitalPublication();
         $webPub->title = 'Migrated ' . date('M j, Y') . ' | ' . $pub->title;
         $webPub->published = false;
         $webPub->is_dsc_stub = false;
         $webPub->save();
+        $this->comment('Starting ' . $pub->title . '...');
 
         $webPubId = $webPub->id;
 
@@ -497,8 +503,10 @@ EOT;
             }
 
             $webPub->articles()->save($webArticle);
+            $this->info($pub->title . ': ' . $webArticle->title);
         }
 
         $webPub->save();
+        $this->comment('...' . $pub->title . ' done!');
     }
 }

--- a/app/Console/Commands/MigrateOSCIPublicationOne.php
+++ b/app/Console/Commands/MigrateOSCIPublicationOne.php
@@ -32,14 +32,14 @@ class MigrateOSCIPublicationOne extends Command
 
     /**
      * mediaFactory
-     * 
-     * Fetches asset for this figure layer and registers it as Media, 
+     *
+     * Fetches asset for this figure layer and registers it as Media,
      * applying caption and using OSCI's fallback URL
-     *  
+     *
      * @param imageData - JSON of image data for this layer
      * @param caption_html - HTML of caption data
      * @param fallback_url - Fallback image to use for this layer
-     * 
+     *
      */
     private function mediaFactory($imageData, $caption_html, $fallback_url)
     {
@@ -97,7 +97,7 @@ class MigrateOSCIPublicationOne extends Command
             case $figure->figure_type === 'html_figure' && !isset($figure->html_content_src):
                 $block->type = 'media_embed';
                 $block->content = [
-                    "size" => "m",
+                    "size" => "s",
                     "embed_type" => "html",
                     "embed_code" => $figure->html_content,
                     "embed_height" => "400px",
@@ -113,7 +113,7 @@ class MigrateOSCIPublicationOne extends Command
                 $block->type = 'video';
 
                 $block->content = [
-                    "size" => "m",
+                    "size" => "s",
                     "media_type" => "youtube",
                     "url" => $figure->html_content_src
                 ];
@@ -127,7 +127,7 @@ class MigrateOSCIPublicationOne extends Command
                 $block->content = [
                   "is_modal" => false,
                   "is_zoomable" => false,
-                  "size" => "m",
+                  "size" => "s",
                   "use_contain" => true,
                   "use_alt_background" => true,
                   "image_link" => null,
@@ -160,7 +160,7 @@ class MigrateOSCIPublicationOne extends Command
                 $block->type = 'layered_image_viewer';
                 $block->editor_name = 'default';
                 $block->content = [
-                  "size" => "m",
+                  "size" => "s",
                   "caption" => $figure->caption_html,
                 ];
 
@@ -232,7 +232,7 @@ class MigrateOSCIPublicationOne extends Command
                 $block->content = [
                   "is_modal" => false,
                   "is_zoomable" => false,
-                  "size" => "m",
+                  "size" => "s",
                   "use_contain" => true,
                   "use_alt_background" => true,
                   "image_link" => null,
@@ -266,7 +266,7 @@ class MigrateOSCIPublicationOne extends Command
             case '360_slider':
                 $block->type = '360_embed';
                 $block->content = [
-                    "size" => "m",
+                    "size" => "s",
                     "caption" => $figure->caption_html
                 ];
 

--- a/app/Console/Commands/MigrateOSCIPublicationOne.php
+++ b/app/Console/Commands/MigrateOSCIPublicationOne.php
@@ -3,26 +3,12 @@
 namespace App\Console\Commands;
 
 use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Arr;
 use App\Repositories\Api\PublicationRepository;
 use App\Models\DigitalPublication;
 use App\Models\DigitalPublicationArticle;
 use App\Models\Vendor\Block;
-
-/**
- * MigrationDB 
- * 
- * Wrapper around the migration db -- basically just an open()-er?
- * 
- * TODO: construct() should take a migration filename string
- */
-class MigrationDB extends \SQLite3 {
-
-    function __construct()
-    {
-        $this->open('migration.sqlite3');
-    }
-
-}
 
 class MigrateOSCIPublicationOne extends Command
 {
@@ -40,21 +26,6 @@ class MigrateOSCIPublicationOne extends Command
      */
     protected $description = 'Migrate an OSCI publication from a migration file to a website DigitalPublication';
 
-    protected $db;
-
-    /**
-     * Create a new command instance.
-     *
-     * @return void
-     * 
-     * TODO: This should take.. a migration filename?
-     */
-    public function __construct()
-    {
-        $this->db = new MigrationDB();
-        parent::__construct();
-    }
-
     /**
      * Execute the console command.
      *
@@ -66,34 +37,27 @@ class MigrateOSCIPublicationOne extends Command
 
         // NB!: For each of these types in the admin UI it's impossible to validate the save without setting a date!
 
-        $pubQuery = $this->db->prepare("SELECT json_extract(publications.data,'$._title') as title FROM publications LEFT JOIN tocs ON tocs.package=publications.pub_id WHERE pub_id=:id");
-        $pubQuery->bindValue(':id',$pubId);
-
-        $result = $pubQuery->execute();
-        $pub = $result->fetchArray();
+        $pubs = DB::connection('osci_migration')->select("SELECT json_extract(publications.data,'$._title') as title FROM publications LEFT JOIN tocs ON tocs.package=publications.pub_id WHERE pub_id=:id", ['id' => $pubId]);
+        $pub = Arr::first($pubs);
 
         // TODO: Handle italics / etc in the title
         // TODO: Set any other publication level metadata (date?)
 
         $webPub = new DigitalPublication();
-        $webPub->title = 'Migrated ' . date('M j, Y') . ' | ' . $pub["title"];
+        $webPub->title = 'Migrated ' . date('M j, Y') . ' | ' . $pub->title;
         $webPub->published = false;
         $webPub->is_dsc_stub = false;
         $webPub->save();
 
         $webPubId = $webPub->id;
 
-        $textsQuery = $this->db->prepare("SELECT coalesce(json_extract(data,'$._title'),'FIXME') as title,text_id FROM texts WHERE package=:pubId and text_id NOT LIKE '%ncxtoc%'");
-        $textsQuery->bindValue(':pubId',$pubId);
+        $texts = DB::connection('osci_migration')->select("SELECT coalesce(json_extract(data,'$._title'),'FIXME') as title,text_id FROM texts WHERE package=:pubId and text_id NOT LIKE '%ncxtoc%'", ['pubId' => $pubId]);
 
-        $textResult = $textsQuery->execute();
-        $text = $textResult->fetchArray();
+        foreach ($texts as $text) {
 
-        while ($text) {
-            
             $webArticle = new DigitalPublicationArticle();
             $webArticle->type = "text";
-            $webArticle->title = $text['title'];
+            $webArticle->title = $text->title;
             $webArticle->published = false;
             $webArticle->digital_publication_id = $webPubId;
             $webArticle->date = date('M j, Y');
@@ -101,23 +65,17 @@ class MigrateOSCIPublicationOne extends Command
             $webArticle->created_at = date('M j, Y');
 
             // TODO: Join toc position via json_tree against toc data
-            $webArticle->position = 0; 
+            $webArticle->position = 0;
 
             $webArticle->save();
 
             // TODO: Use a multiline string!! Also this can be moved outside the while
 
-            $blocksQuery = $this->db->prepare("SELECT json_extract(blk.value,'$.html') as html, blk.id as position, json_extract(blk.value,'$.blockType') as type, json_extract(blk.value,'$.fallback_url') as figure_url, coalesce(json_extract(blk.value,'$.caption_html'),'') as figure_capt from texts, json_each(texts.data,'$.sections') as sects,json_each(sects.value,'$.blocks') as blk where texts.text_id=:textId");
-
-            $blocksQuery->bindValue(':textId',$text['text_id']);
-
-            $blocksResult = $blocksQuery->execute();
-
-            $blk = $blocksResult->fetchArray();
+            $blocks = DB::connection('osci_migration')->select("SELECT json_extract(blk.value,'$.html') as html, blk.id as position, json_extract(blk.value,'$.blockType') as type, json_extract(blk.value,'$.fallback_url') as figure_url, coalesce(json_extract(blk.value,'$.caption_html'),'') as figure_capt from texts, json_each(texts.data,'$.sections') as sects,json_each(sects.value,'$.blocks') as blk where texts.text_id=:textId", ['textId' => $text->text_id]);
 
             $order = 0;
 
-            while ($blk) {
+            foreach ($blocks as $blk) {
 
                 $block = new Block();
                 $block->blockable_id = $webArticle->id;
@@ -126,14 +84,14 @@ class MigrateOSCIPublicationOne extends Command
                 $block->position = $order;
 
                 // TODO: Adapt Trevin's spec image code here
-                if ($blk['type'] == 'figure') {
-                    
+                if ($blk->type == 'figure') {
+
                     // $figText = '<span>'.$blk['figure_url'].'</span>';
-                    $figText = '<figure><img src="'. $blk['figure_url'] . '" alt /><figcaption>'.$blk['figure_capt'].'</figcaption></figure>';
+                    $figText = '<figure><img src="'. $blk->figure_url . '" alt /><figcaption>'.$blk->figure_capt.'</figcaption></figure>';
 
                     $block->content = [ 'paragraph' => $figText ];
                 } else {
-                    $block->content = [ 'paragraph' => $blk['html'] ];
+                    $block->content = [ 'paragraph' => $blk->html ];
                 }
 
                 $block->type = 'paragraph';
@@ -141,17 +99,13 @@ class MigrateOSCIPublicationOne extends Command
 
                 $webArticle->blocks()->save($block);
 
-                $blk = $blocksResult->fetchArray();
                 $order += 1;
             }
 
             $webArticle->save();
             $webPub->articles()->save($webArticle);
-
-            $text = $textResult->fetchArray();
-
         }
-    
+
         $webPub->save();
     }
 }

--- a/app/Console/Commands/MigrateOSCIPublicationOne.php
+++ b/app/Console/Commands/MigrateOSCIPublicationOne.php
@@ -109,7 +109,7 @@ class MigrateOSCIPublicationOne extends Command
 
             $webArticle->save();
 
-            $blocksQuery = $this->db->prepare("SELECT json_extract(blk.value,'$.html') as html, json_extract(blk.value,'$.blockType') as type, json_extract(blk.value,'$.fallback_url') as figure_url from texts,json_each(texts.data,'$.sections') as sects,json_each(sects.value,'$.blocks') as blk where texts.text_id=:textId");
+            $blocksQuery = $this->db->prepare("SELECT json_extract(blk.value,'$.html') as html, blk.id as position, json_extract(blk.value,'$.blockType') as type, json_extract(blk.value,'$.fallback_url') as figure_url from texts,json_each(texts.data,'$.sections') as sects,json_each(sects.value,'$.blocks') as blk where texts.text_id=:textId");
             $blocksQuery->bindValue(':textId',$text['text_id']);
 
             $blocksResult = $blocksQuery->execute();
@@ -117,15 +117,12 @@ class MigrateOSCIPublicationOne extends Command
             $blk = $blocksResult->fetchArray();
 
             while ($blk) {
-                // echo 'sup';
-                // echo $blk['html'];  
-                // TODO: .. and for each text's block, do this dance..
+
                 $block = new Block();
                 $block->blockable_id = $webArticle->id;
                 $block->blockable_type = 'App\Models\DigitalPublicationArticle';
 
-                // TODO
-                $block->position = 0;
+                $block->position = $blk['position'];
 
                 if ($block['type'] == 'figure') {
                     $block->content = [ 'paragraph' => '<figure><img src="'. $block['figure_url'] . '" alt /></figure>' ];

--- a/app/Console/Commands/MigrateOSCIPublicationOne.php
+++ b/app/Console/Commands/MigrateOSCIPublicationOne.php
@@ -109,7 +109,7 @@ class MigrateOSCIPublicationOne extends Command
 
             $webArticle->save();
 
-            $blocksQuery = $this->db->prepare("SELECT json_extract(sects.value,'$.html') as html from texts,json_each(texts.data,'$.sections') as sects where texts.text_id=:textId");
+            $blocksQuery = $this->db->prepare("SELECT json_extract(blk.value,'$.html') as html, json_extract(blk.value,'$.blockType') as type, json_extract(blk.value,'$.fallback_url') as figure_url from texts,json_each(texts.data,'$.sections') as sects,json_each(sects.value,'$.blocks') as blk where texts.text_id=:textId");
             $blocksQuery->bindValue(':textId',$text['text_id']);
 
             $blocksResult = $blocksQuery->execute();
@@ -127,7 +127,12 @@ class MigrateOSCIPublicationOne extends Command
                 // TODO
                 $block->position = 0;
 
-                $block->content = [ 'paragraph' => $blk['html'] ];
+                if ($block['type'] == 'figure') {
+                    $block->content = [ 'paragraph' => '<figure><img src="'. $block['figure_url'] . '" alt /></figure>' ];
+                } else {
+                    $block->content = [ 'paragraph' => $blk['html'] ];
+                }
+
                 $block->type = 'paragraph';
                 $block->save();
 

--- a/app/Console/Commands/MigrateOSCIPublicationOne.php
+++ b/app/Console/Commands/MigrateOSCIPublicationOne.php
@@ -62,8 +62,25 @@ class MigrateOSCIPublicationOne extends Command
 
                 break;
 
-            // TODO: if layered_image instantiate a layered image block
             case 'layered_image':
+                $block->type = 'layered_image_viewer';
+
+                // TODO: Instantiate the layers using fig_layer data, attaching each using fig_layer.data to get titles + layer # / order
+                $block->content = [
+                  "is_modal" => false,
+                  "is_zoomable" => false,
+                  "size" => "m",
+                  "use_contain" => true,
+                  "use_alt_background" => true,
+                  "image_link" => null,
+                  "hide_figure_number" => false,
+                  "caption" => $figure->caption_html,
+                  "alt_text" => ""
+                ];
+
+                $block->save();
+                break;
+
             case 'iip_asset':
                 $block->type = 'image';
 
@@ -87,6 +104,18 @@ class MigrateOSCIPublicationOne extends Command
                 $media->caption = $figure->caption_html;
                 $media->save();
 
+                $block->medias()->attach($media->id, [
+                    'locale' => 'en',
+                    'media_id' => $media->id,
+                    'metadatas' => '{"caption":null,"captionTitle": null, "altText":null,"video":null}',
+                    'role' => 'image',
+                    'crop' => 'desktop',
+                    'crop_x' => 0,
+                    'crop_y' => 0,
+                    'crop_w' => 2246,
+                    'crop_h' => 1469
+                ]);
+
                 $block->content = [
                   "is_modal" => false,
                   "is_zoomable" => false,
@@ -95,19 +124,10 @@ class MigrateOSCIPublicationOne extends Command
                   "use_alt_background" => true,
                   "image_link" => null,
                   "hide_figure_number" => false,
-                  "caption" => $figure->caption_html
+                  "caption" => $figure->caption_html,
+                  "alt_text" => ""
                 ];
-                
-                $block->medias()->save($media, [
-                    'metadatas' => '{"caption":null,"altText":null,"video":null}',
-                    'role' => 'default',
-                    'crop' => 'default',
-                    'ratio' => 0,
-                    'crop_x' => 0,
-                    'crop_y' => 0,
-                    'crop_w' => 2246,
-                    'crop_h' => 1469
-                ]);
+
                 $block->save();
                 // $block->medias()->sync([]);
                 // var_dump($block);

--- a/app/Console/Commands/MigrateOSCIPublicationOne.php
+++ b/app/Console/Commands/MigrateOSCIPublicationOne.php
@@ -29,69 +29,87 @@ class MigrateOSCIPublicationOne extends Command
      */
     protected $description = 'Migrate an OSCI publication from a migration file to a website DigitalPublication';
 
+    private function mediaFactory($imageData, $caption_html, $fallback_url)
+    {
+
+        // Media uploads and relations
+        $imageUrl = isset($imageData->static_url) ? $imageData->static_url : $fallback_url ;
+
+        $imageUuid = (string) Str::uuid();
+        $imageUrlPath = parse_url($imageUrl, PHP_URL_PATH);
+        $imageExt = pathinfo($imageUrlPath, PATHINFO_EXTENSION);
+        $imageFilename = Str::random(10) . $imageExt;
+
+        $imageName = $imageUuid . '/' . $imageFilename;
+
+        $ctx = stream_context_create(array(
+                'http' =>
+                    array(
+                        'timeout' => 120,
+                    )
+                ));
+        $imageContent = file_get_contents($imageUrl, false, $ctx);
+
+        Storage::disk('s3')->put($imageName, $imageContent);
+
+        // TODO: Use the CMS's onboard h/w helpers
+        $media = new Media([
+                    'uuid' => $imageName,
+                    'width' => $imageData->width,
+                    'height' => $imageData->height,
+                    'filename' => $imageFilename,
+                    'locale' => 'en'
+                ]);
+
+        $media->alt_text = 'Alt text for the image';
+        $media->caption = $caption_html;
+        $media->save();
+
+        return $media;
+    }
     /**
      * configure $block (a Block model) with $data
      *
      */
     private function configureFigBlock($figure, $block)
     {
-        switch ($figure->figure_type) {
-            case 'html_figure':
+
+        $layers = isset($figure->layers_data) ? json_decode($figure->layers_data) : [];
+
+        // TODO: if html_figure and html_content_src, that's a video block bby
+        switch (true) {
+            // Non-video embeds (HTML, mostly) become media_embed
+            case $figure->figure_type === 'html_figure' && !isset($figure->html_content_src):
                 $block->type = 'media_embed';
-
-                if (isset($figure->html_content_src)) {
-                    $block->content = [
-                        "size" => "m",
-                        "embed_type" => "url",
-                        "embed_url" => $figure->html_content_src,
-                        "embed_height" => "400px",
-                        "disable_placeholder" => true
-                    ];
-
-                } else {
-                    $block->content = [
-                        "size" => "m",
-                        "embed_type" => "html",
-                        "embed_code" => $figure->html_content,
-                        "embed_height" => "400px",
-                        "disable_placeholder" => true
-                    ];                    
-                }
-
-                $block->save();
-
-                break;
-
-            case 'layered_image':
-                $block->type = 'layered_image_viewer';
-
-                // TODO: Instantiate the layers using fig_layer data, attaching each using fig_layer.data to get titles + layer # / order
                 $block->content = [
-                  "is_modal" => false,
-                  "is_zoomable" => false,
-                  "size" => "m",
-                  "use_contain" => true,
-                  "use_alt_background" => true,
-                  "image_link" => null,
-                  "hide_figure_number" => false,
-                  "caption" => $figure->caption_html,
-                  "alt_text" => ""
+                    "size" => "m",
+                    "embed_type" => "html",
+                    "embed_code" => $figure->html_content,
+                    "embed_height" => "400px",
+                    "disable_placeholder" => true,
+                    "caption" => $figure->caption_html
                 ];
-
                 $block->save();
+
                 break;
 
-            case 'iip_asset':
+            // HTML embeds with a src are videos
+            case $figure->figure_type === 'html_figure' && isset($figure->html_content_src):
+                $block->type = 'video';
+
+                $block->content = [
+                    "size" => "m",
+                    "media_type" => "youtube",
+                    "url" => $figure->html_content_src
+                ];
+                $block->save();
+
+                break;
+
+            // OSCI's layered_image with only one layer should just be an image
+            // TODO: Move IIP handling to a func and handle iip_asset in this `case`
+            case 'layered_image' && count($layers) === 1:
                 $block->type = 'image';
-
-
-                // Media uploads and relations
-                $imagePath = isset($figure->static_url) ? $figure->static_url : $figure->fallback_url ;
-                $imageUuid = (string) Str::uuid();
-                $imageFilename = Str::random(10) . '.jpg';
-                $imageName = $imageUuid . '/' . $imageFilename;
-
-                Storage::disk('s3')->put($imageName, file_get_contents($imagePath));
                 $block->content = [
                   "is_modal" => false,
                   "is_zoomable" => false,
@@ -103,21 +121,12 @@ class MigrateOSCIPublicationOne extends Command
                   "caption" => $figure->caption_html,
                   "alt_text" => ""
                 ];
-
                 $block->save();
 
-                $media = new Media([
-                            'uuid' => $imageName,
-                            'width' => 2246,
-                            'height' => 1469,
-                            'filename' => $imageFilename,
-                            'locale' => 'en'
-                        ]);
+                $imageData = Arr::first($layers);
+                $media = $this->mediaFactory($imageData, $figure->caption_html, $figure->fallback_url);
 
-                $media->alt_text = 'Alt text for the image';
-                $media->caption = $figure->caption_html;
-                $media->save();
-
+                // TODO: Use converted crop params
                 $block->medias()->attach($media->id, [
                     'locale' => 'en',
                     'media_id' => $media->id,
@@ -126,8 +135,114 @@ class MigrateOSCIPublicationOne extends Command
                     'crop' => 'desktop',
                     'crop_x' => 0,
                     'crop_y' => 0,
-                    'crop_w' => 2246,
-                    'crop_h' => 1469
+                    'crop_w' => $imageData->width,
+                    'crop_h' => $imageData->height
+                ]);
+
+                $block->save();
+                break;
+
+            case 'layered_image':
+                $block->type = 'layered_image_viewer';
+                $block->editor_name = 'default';
+                $block->content = [
+                  "size" => "m",
+                  "caption" => $figure->caption_html,
+                ];
+
+                $block->save();
+
+                foreach ($layers as $imageData) {
+                    // Each layer (image or overview) is a child block of the layered image viewer block, so:
+                    // - Create media record + move the asset (if not moved already)
+                    // - Configure a layer block for this layer (image or overview)
+                    // - Attach it to the layer viewer block
+
+                    $media = $this->mediaFactory($imageData, $figure->caption_html, $figure->fallback_url);
+
+                    $layerBlock = new Block();
+                    $layerBlock->blockable_id = $block->blockable_id;
+                    $layerBlock->blockable_type =  'digitalPublicationArticles';
+                    $layerBlock->position = 1; // TODO: order
+                    $layerBlock->parent_id = $block->id;
+
+                    // OSCI doesn't expose overlay vs image data so parse the URL filename
+                    $imageUrl = isset($imageData->static_url) ? $imageData->static_url : $figure->fallback_url ;
+                    $imageUrlPath = parse_url($imageUrl, PHP_URL_PATH);
+                    $imageExt = pathinfo($imageUrlPath, PATHINFO_EXTENSION);
+
+                    switch ($imageExt) {
+                        case 'svg':
+                            $layerBlock->child_key = 'layered_image_viewer_overlay';
+                            $layerBlock->type = 'layered_image_viewer_overlay';
+                            break;
+
+                        default:
+                            $layerBlock->child_key = 'layered_image_viewer_img';
+                            $layerBlock->type = 'layered_image_viewer_img';
+                            break;
+                    }
+
+
+                    $layerBlock->content = [
+                      "label" => $imageData->title
+                    ];
+
+                    $layerBlock->save();
+
+                    // TODO: Use converted crop params
+                    $layerBlock->medias()->attach($media->id, [
+                        'locale' => 'en',
+                        'media_id' => $media->id,
+                        'metadatas' => '{"caption":null,"captionTitle": null, "altText":null,"video":null}',
+                        'role' => 'image',
+                        'crop' => 'desktop',
+                        'crop_x' => 0,
+                        'crop_y' => 0,
+                        'crop_w' => $imageData->width,
+                        'crop_h' => $imageData->height
+                    ]);
+                    $layerBlock->save();
+
+                    $block->children()->save($layerBlock);
+                    $block->save();
+                }
+
+                $block->save();
+                break;
+
+            case 'iip_asset':
+                // TODO: Properly handle the IIP asset (finally!)
+                $block->type = 'image';
+                $block->content = [
+                  "is_modal" => false,
+                  "is_zoomable" => false,
+                  "size" => "m",
+                  "use_contain" => true,
+                  "use_alt_background" => true,
+                  "image_link" => null,
+                  "hide_figure_number" => false,
+                  "caption" => $figure->caption_html,
+                  "alt_text" => ""
+                ];
+
+                $block->save();
+
+                $imageData = Arr::first($layers);
+
+                $media = $this->mediaFactory($imageData, $figure->caption_html, $figure->fallback_url);
+
+                // TODO: Use converted crop params
+                $block->medias()->attach($media->id, [
+                    'locale' => 'en',
+                    'media_id' => $media->id,
+                    'metadatas' => '{"caption":null,"captionTitle": null, "altText":null,"video":null}',
+                    'role' => 'image',
+                    'crop' => 'desktop',
+                    'crop_x' => 0,
+                    'crop_y' => 0,
+                    'crop_w' => $imageData->width,
+                    'crop_h' => $imageData->height
                 ]);
 
                 $block->save();
@@ -135,7 +250,7 @@ class MigrateOSCIPublicationOne extends Command
 
             case '360_slider':
                 $block->type = '360_embed';
-                $block->content = [ 
+                $block->content = [
                     "size" => "m",
                     "caption" => $figure->caption_html
                 ];
@@ -147,7 +262,7 @@ class MigrateOSCIPublicationOne extends Command
             case 'rti_viewer':
                 // TODO: insert reader_url, figure # for this text + figure
                 $block->type = 'video';
-                $block->content = [ 
+                $block->content = [
                     "caption" => $figure->caption_html
                 ];
 
@@ -185,11 +300,12 @@ class MigrateOSCIPublicationOne extends Command
 
         // NB!: For each of these types in the admin UI it's impossible to validate the save without setting a date!
 
+        // Fetch this publication's title by its package name (eg, `caillebotte`)
+        // TODO: Handle italics / etc in the title
+        // TODO: Set publication date metadata
+
         $pubs = DB::connection('osci_migration')->select("SELECT json_extract(publications.data,'$._title') as title FROM publications LEFT JOIN tocs ON tocs.package=publications.pub_id WHERE pub_id=:id", ['id' => $pubId]);
         $pub = Arr::first($pubs);
-
-        // TODO: Handle italics / etc in the title
-        // TODO: Set any other publication level metadata (date?)
 
         $webPub = new DigitalPublication();
         $webPub->title = 'Migrated ' . date('M j, Y') . ' | ' . $pub->title;
@@ -199,24 +315,50 @@ class MigrateOSCIPublicationOne extends Command
 
         $webPubId = $webPub->id;
 
+        // Now select all this pub's texts
         $texts = DB::connection('osci_migration')->select("SELECT coalesce(json_extract(data,'$._title'),'FIXME') as title,text_id FROM texts WHERE package=:pubId", ['pubId' => $pubId]);
 
         // Initialize the left value
         $lft = 1;
 
-        $blockQuery = "SELECT json_extract(blk.value,'$.html') AS html," .
-                          "blk.id AS position," .
-                          "json_extract(blk.value,'$.blockType') AS type," .
-                          "json_extract(blk.value,'$.figure_type') AS figure_type," .
-                          "json_extract(blk.value,'$.static_url') AS static_url," .
-                          "json_extract(blk.value,'$.fallback_url') AS fallback_url," .
-                          "json_extract(blk.value,'$.html_content') AS html_content," .
-                          "json_extract(blk.value,'$.html_content_src') AS html_content_src," .
-                          "coalesce(json_extract(blk.value,'$.caption_html'),'') AS caption_html " .
-                          "FROM texts," .
-                          "json_each(texts.data,'$.sections') AS sects," .
-                          "json_each(sects.value,'$.blocks') AS blk " .
-                          "WHERE texts.text_id=:textId";
+        // Fetch sections and blocks by text ID (joined to their figure assets)
+        // NB: `layers_data` is a JSON array of layer asset objects
+
+        // TODO: Add `toc_position`, `toc_parent` via json_tree against toc data
+        $blockQuery = <<<EOT
+WITH layers (layers_url,layers_data) AS (
+    SELECT json_extract(figure_layers.data,'$._asset_url') AS layers_url,
+        json_group_array(
+            json_object(
+                'layer_id',json_extract(layers.value,'$._layer_id'),
+                'static_url',json_extract(layers.value,'$._static_url'),
+                'image_ident',json_extract(layers.value,'$._image_ident'),
+                'image_url_stem',json_extract(layers.value,'$._image_url_stem'),
+                'title',coalesce(json_extract(layers.value,'$._title'),''),
+                'height', json_extract(layers.value,'$._height'),
+                'width', json_extract(layers.value,'$._width')
+            )
+        ) AS layers_data
+    FROM figure_layers,
+        json_each(figure_layers.data,'$.layers') as layers
+    GROUP BY layers_url
+)
+SELECT json_extract(blk.value,'$.html') AS html,
+                  blk.id AS position,
+                  json_extract(blk.value,'$.blockType') AS type,
+                  json_extract(blk.value,'$.figure_type') AS figure_type,
+                  json_extract(blk.value,'$.fallback_url') AS fallback_url,
+                  json_extract(blk.value,'$.html_content') AS html_content,
+                  json_extract(blk.value,'$.html_content_src') AS html_content_src,
+                  coalesce(json_extract(blk.value,'$.caption_html'),'') AS caption_html,
+                  layers.layers_url AS layers_url,
+                  layers.layers_data AS layers_data
+                  FROM texts,
+                  json_each(texts.data,'$.sections') AS sects,
+                  json_each(sects.value,'$.blocks') AS blk
+                    LEFT JOIN layers on json_extract(blk.value,'$.figure_layer_url')=layers.layers_url
+                  WHERE texts.text_id=:textId
+EOT;
 
         foreach ($texts as $text) {
             $webArticle = new DigitalPublicationArticle();
@@ -230,7 +372,6 @@ class MigrateOSCIPublicationOne extends Command
             $webArticle->_lft = $lft++;
             $webArticle->_rgt = $lft++;
 
-            // TODO: Join toc position via json_tree against toc data
             $webArticle->position = 0;
 
             $webArticle->save();

--- a/app/Console/Commands/MigrateOSCIPublicationOne.php
+++ b/app/Console/Commands/MigrateOSCIPublicationOne.php
@@ -57,7 +57,6 @@ class MigrateOSCIPublicationOne extends Command
         $lft = 1;
 
         foreach ($texts as $text) {
-
             $webArticle = new DigitalPublicationArticle();
             $webArticle->type = "text";
             $webArticle->title = $text->title;
@@ -81,7 +80,6 @@ class MigrateOSCIPublicationOne extends Command
             $order = 0;
 
             foreach ($blocks as $blk) {
-
                 $block = new Block();
                 $block->blockable_id = $webArticle->id;
                 $block->blockable_type = 'App\Models\DigitalPublicationArticle';
@@ -90,9 +88,8 @@ class MigrateOSCIPublicationOne extends Command
 
                 // TODO: Adapt Trevin's spec image code here
                 if ($blk->type == 'figure') {
-
                     // $figText = '<span>'.$blk['figure_url'].'</span>';
-                    $figText = '<figure><img src="'. $blk->figure_url . '" alt /><figcaption>'.$blk->figure_capt.'</figcaption></figure>';
+                    $figText = '<figure><img src="' . $blk->figure_url . '" alt /><figcaption>' . $blk->figure_capt . '</figcaption></figure>';
 
                     $block->content = [ 'paragraph' => $figText ];
                 } else {

--- a/app/Console/Commands/MigrateOSCIPublicationOne.php
+++ b/app/Console/Commands/MigrateOSCIPublicationOne.php
@@ -85,15 +85,8 @@ class MigrateOSCIPublicationOne extends Command
 
         $imageName = $imageUuid . '/' . $imageFilename;
 
-        $http_ctx = stream_context_create(array(
-                        'http' => [
-                            'timeout' => 120,
-                            'ignore_errors' => true,
-                        ]
-                    ));
-
         $retries = 0;
-        while ($imageContent === false && $retries < 5 ) {
+        while ($imageContent === false && $retries < 5) {
             // Fetch the URL, retrying if it's not a 404
             try {
                 $resp = Http::get($imageUrl);

--- a/app/Http/Requests/Admin/SlideRequest.php
+++ b/app/Http/Requests/Admin/SlideRequest.php
@@ -19,7 +19,7 @@ class SlideRequest extends Request
         return [
             'attract_title' => 'max:150',
             'attract_subhead' => 'max:150',
-            'section_title' => 'max:150',
+            'article_title' => 'max:150',
             'caption' => 'max:150',
             'interstitial_headline' => 'max:150',
             'body_copy' => 'max:500',

--- a/app/Http/Resources/Slide.php
+++ b/app/Http/Resources/Slide.php
@@ -121,10 +121,10 @@ class Slide extends JsonResource
         $this->media = $this->interstitialExperienceImage;
 
         return [
-            'title' => $this->section_title,
+            'title' => $this->article_title,
             'copy' => $this->body_copy,
             '__option_body_copy' => !empty($this->body_copy),
-            '__option_section_title' => !empty($this->section_title),
+            '__option_article_title' => !empty($this->article_title),
             '__option_background_image' => count($this->interstitialExperienceImage) > 0,
             '__option_headline' => !empty($this->interstitial_headline),
         ];

--- a/app/Models/Api/Asset.php
+++ b/app/Models/Api/Asset.php
@@ -148,7 +148,7 @@ class Asset extends BaseApiModel
     public function scopeMultimediaAssets($query)
     {
         $params = [
-            'resources' => ['images', 'sounds', 'texts', 'videos', 'sections', 'sites']
+            'resources' => ['images', 'sounds', 'texts', 'videos', 'articles', 'sites']
         ];
 
         return $query->rawQuery($params);

--- a/app/Models/Api/Publication.php
+++ b/app/Models/Api/Publication.php
@@ -12,8 +12,8 @@ class Publication extends BaseApiModel
         'search' => '/api/v1/publications/search'
     ];
 
-    public function sections()
+    public function articles()
     {
-        return $this->hasMany(\App\Models\Api\Section::class, 'section_ids');
+        return $this->hasMany(\App\Models\Api\Section::class, 'article_ids');
     }
 }

--- a/app/Models/Experience.php
+++ b/app/Models/Experience.php
@@ -277,6 +277,11 @@ class Experience extends AbstractModel implements Sortable
         return StringHelpers::getUtf8Slug($this->title);
     }
 
+    public function getTitleSlugAttribute()
+    {
+        return StringHelpers::getUtf8Slug($this->title);
+    }
+
     public $mediasParams = [
         'thumbnail' => [
             'default' => [

--- a/config/aic.php
+++ b/config/aic.php
@@ -19,6 +19,10 @@ return [
     'pdf_s3_endpoint' => env('PDF_S3_ENDPOINT'),
     'pdf_debug' => (bool) env('PDF_DEBUG', false),
 
+    'osci_s3_bucket' => env('OSCI_S3_BUCKET'),
+    'osci_s3_endpoint' => env('OSCI_S3_ENDPOINT'),
+    'osci_s3_regiont' => env('OSCI_S3_REGION'),
+
     'disable_extra_scripts' => (bool) env('DISABLE_EXTRA_SCRIPTS', false),
 
     'hide_from_tours' => env('HIDE_FROM_TOURS'),

--- a/config/database.php
+++ b/config/database.php
@@ -115,6 +115,15 @@ return [
             'sslmode' => 'prefer',
         ],
 
+        'osci_migration' => [
+            'driver' => 'sqlite',
+            'database' => storage_path('app/migration.sqlite3'),
+            'prefix' => '',
+            'foreign_key_constraints' => true,
+        ],
+
+
+
     ],
 
     /*

--- a/config/filesystems.php
+++ b/config/filesystems.php
@@ -74,6 +74,16 @@ return [
             'endpoint' => env('PDF_S3_ENDPOINT'),
             'use_path_style_endpoint' => env('AWS_USE_PATH_STYLE_ENDPOINT', false),
         ],
+
+        'osci_s3' => [
+            'driver' => 's3',
+            'key' => env('S3_KEY'),
+            'secret' => env('S3_SECRET'),
+            'region' => env('OSCI_S3_REGION', env('S3_REGION')),
+            'bucket' => env('OSCI_S3_BUCKET'),
+            'endpoint' => env('OSCI_S3_ENDPOINT'),
+            'use_path_style_endpoint' => env('AWS_USE_PATH_STYLE_ENDPOINT', false),
+        ],
     ],
 
     /*

--- a/resources/views/admin/digitalPublications/articles/form.blade.php
+++ b/resources/views/admin/digitalPublications/articles/form.blade.php
@@ -46,7 +46,7 @@
                 'label' => 'Hide title in listing view',
             ])
         @endslot
-        
+
         @slot('right')
             @formField('checkbox', [
                 'name' => 'suppress_listing',

--- a/resources/views/admin/experiences/slides/_interstitial.blade.php
+++ b/resources/views/admin/experiences/slides/_interstitial.blade.php
@@ -4,8 +4,8 @@
     'keepAlive' => true,
 ])
     @formField('wysiwyg', [
-        'name' => 'section_title',
-        'label' => 'Section Title',
+        'name' => 'article_title',
+        'label' => 'Article Title',
         'maxlength' => 150,
     ])
 

--- a/resources/views/site/digitalPublicationDetail.blade.php
+++ b/resources/views/site/digitalPublicationDetail.blade.php
@@ -258,7 +258,7 @@
                             @slot('cols_large','3')
                             @slot('cols_xlarge','3')
                     @endif
-                
+
                     @foreach ($topLevelArticle->children->filter(function($item) {
                         return !$item->suppress_listing;
                     })->sortBy('position') as $item)
@@ -294,14 +294,14 @@
                             @endcomponent
                         @endif
                     @endforeach
-                
+
                     @if ($showAll == true)
                         @endcomponent
                     @endif
-                
+
                 @break
                 @default
-                
+
                     @component('components.organisms._o-grid-listing')
                         @slot('cols_small','2')
                         @slot('cols_medium','3')
@@ -336,7 +336,7 @@
                             @endif
                         @endforeach
                     @endcomponent
-                
+
                 @endswitch
             @endif
         @endforeach


### PR DESCRIPTION
This pull request updates `migrate:osci-publication` to use the sqlite database produced by the codebase in `https://github.com/art-institute-of-chicago/osci-migration` . 

To use the new command, put the migration file from https://github.com/art-institute-of-chicago/osci-migration/blob/feature/errata-and-blocks/admin/src/data/migration.sqlite3 in your path and run `twill migrate:osci-publication <id>` where `<id>` is a publication id from the `publications` table (also visible here -- https://feature-errata-and-blocks--osci-migration.netlify.app ).