### PR TITLE
Adjust showcase RLC teal variation

### DIFF
--- a/frontend/scss/molecules/_m-showcase.scss
+++ b/frontend/scss/molecules/_m-showcase.scss
@@ -167,38 +167,6 @@
         &.showcase--variation-rlc-secondary {
             background-color: $color__rlc__myrtle_green !important;
 
-            .m-showcase-wrapper {
-                flex-direction: row-reverse;
-
-                .showcase-header {
-                    flex-basis: 100%;
-                    order: -1;
-                }
-
-                @include breakpoint('xsmall') {
-                    flex-direction: column-reverse;
-
-                    .showcase-header {
-                        flex-basis: fit-content;
-                        order: 1;
-                    }
-                }
-            }
-
-            .m-showcase-media {
-                .m-media__img {
-                    background-color: inherit;
-
-                    img {
-                        aspect-ratio: 1;
-                    }
-                }
-
-                @include breakpoint('small+') {
-                    flex: 2;
-                }
-            }
-
             .showcase-header,
             .showcase-tag,
             .showcase-title,


### PR DESCRIPTION
This change makes the showcase blocks "RLC secondary" styled more like the default showcase variation instead of the "About the RCL" variation.