### PR TITLE
Make date field available for all RLC showcase blocks

### DIFF
--- a/resources/views/admin/blocks/showcase.blade.php
+++ b/resources/views/admin/blocks/showcase.blade.php
@@ -167,17 +167,11 @@
     'fieldValues' => 'rlc',
     'renderForBlocks' => true,
 ])
-    @formConnectedFields([
-        'fieldName' => 'variation',
-        'fieldValues' => 'default',
-        'renderForBlocks' => true,
+    @formField('input', [
+        'name' => 'date',
+        'label' => 'Date',
+        'type' => 'text',
     ])
-        @formField('input', [
-            'name' => 'date',
-            'label' => 'Date',
-            'type' => 'text',
-        ])
-    @endcomponent
 @endcomponent
 
 @component('twill::partials.form.utils._columns')


### PR DESCRIPTION
For some reason I had made the Date input available for only the default showcase variation of the RLC theme. This change corrects that.