### PR TITLE
Make showcase date visible for RLC theme

### DIFF
--- a/frontend/scss/molecules/_m-showcase.scss
+++ b/frontend/scss/molecules/_m-showcase.scss
@@ -173,6 +173,10 @@
             .showcase-description {
                 color: $color__white;
             }
+            .showcase-date {
+                margin-top: 28px;
+                color: $color__rlc__sunglow;
+            }
             .showcase-link {
                 color: $color__rlc__sunglow;
                 &:hover {

--- a/resources/views/site/blocks/showcase.blade.php
+++ b/resources/views/site/blocks/showcase.blade.php
@@ -61,7 +61,7 @@
                     {!! SmartyPants::defaultTransform($description) !!}
                 @endcomponent
             @endif
-            @if ($date && ($theme == 'rlc' && $variation == 'default'))
+            @if ($date && ($theme == 'rlc'))
                 @component('components.blocks._text')
                     @slot('tag', 'div')
                     @slot('font', 'f-secondary')


### PR DESCRIPTION
This change makes sure the date text is visible for all RLC showcase variations and colors it the same as the link text.