### PR TITLE
Fix unsticky header

### DIFF
--- a/frontend/scss/state/_s-unsticky-header.scss
+++ b/frontend/scss/state/_s-unsticky-header.scss
@@ -12,6 +12,21 @@ For those times when you just don't want the navigation to get in the way of the
     padding-top: 0;
     .g-header {
       position: relative;
+      .g-header__inner {
+        border-bottom: 0;
+      }
+      &:has(a[role="menuitem"][aria-expanded="true"]) {
+        position: fixed;
+
+        & ~ main#content {
+          @include breakpoint('small+') {
+            padding-top: 128px;
+          }
+          @include breakpoint('medium+') {
+            padding-top: 140px;
+          }
+        }
+      }
     }
 
     .top-link {

--- a/frontend/scss/state/_s-unsticky-header.scss
+++ b/frontend/scss/state/_s-unsticky-header.scss
@@ -15,6 +15,7 @@ For those times when you just don't want the navigation to get in the way of the
       .g-header__inner {
         border-bottom: 0;
       }
+      &:hover,
       &:has(a[role="menuitem"][aria-expanded="true"]) {
         position: fixed;
 

--- a/frontend/scss/state/_s-unsticky-header.scss
+++ b/frontend/scss/state/_s-unsticky-header.scss
@@ -37,5 +37,25 @@ For those times when you just don't want the navigation to get in the way of the
 
   &.s-contrast-header #a17 .g-header {
     position: absolute;
+    @include breakpoint('small+') {
+      height: 128px;
+    }
+    @include breakpoint('medium+') {
+      height: 140px;
+    }
+    &:hover {
+      position: fixed;
+      &:has(a[role="menuitem"][aria-expanded="true"]) {
+        @include breakpoint('small') {
+          height: 368px;
+        }
+        @include breakpoint('medium') {
+          height: 376px;
+        }
+        @include breakpoint('large+') {
+          height: 380px;
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
This addresses the page content being shifted down when the menu is opened as well as the placement of the menu when the page is partially scrolled.