### PR TITLE
QA fixes for DigiPub sticky header

### DIFF
--- a/frontend/scss/molecules/_m-article-header.scss
+++ b/frontend/scss/molecules/_m-article-header.scss
@@ -1138,15 +1138,20 @@
     }
   }
   @include breakpoint('medium-') {
-    .s-sticky-digital-publication-header &~.m-sidebar-toggle {
-      position: fixed;
-      top: 0;
-      width: 100vw;
-      z-index: map-get($zindexs, 'header');
+    .s-sticky-digital-publication-header {
+      &~.m-sidebar-toggle {
+        position: fixed;
+        top: 0;
+        width: 100vw;
+        z-index: map-get($zindexs, 'header');
 
-      &::before {
-        left: 0;
-        width: 150vw;
+        &::before {
+          left: 0;
+          width: 150vw;
+        }
+      }
+      .m-article-header__spacer {
+        min-height: 54px;
       }
     }
   }

--- a/frontend/scss/molecules/_m-article-header.scss
+++ b/frontend/scss/molecules/_m-article-header.scss
@@ -1163,14 +1163,19 @@
     }
 
     .s-shrinking-digital-publication-header.s-scroll-direction-down & {
+      .m-article-header__img img {
+        opacity: 0;
+        transition: opacity 2s;
+      }
+
       .title {
         opacity: 0;
-        transition: opacity 1s;
+        transition: opacity 2s;
       }
 
       .subtitle {
         opacity: 0;
-        transition: opacity 1s;
+        transition: opacity 2s;
       }
     }
 
@@ -1198,7 +1203,13 @@
       }
 
       .m-article-header__img {
+        flex: 0 0 auto;
         height: 180px;
+
+        img {
+          opacity: 1;
+          transition: opacity 2s;
+        }
       }
     }
 
@@ -1216,6 +1227,10 @@
       height: 75vh;
       right: 50%;
       margin-right: -50vw;
+
+      &::before {
+        z-index: -1;
+      }
     }
   }
 
@@ -1228,11 +1243,6 @@
       left: -300%;
       margin-left: 0;
       max-width: colspan(50, 'xlarge');
-    }
-    .m-article-header__img {
-      height: 75vh;
-      right: 50%;
-      margin-right: -50vw;
     }
   }
 }

--- a/frontend/scss/molecules/_m-article-header.scss
+++ b/frontend/scss/molecules/_m-article-header.scss
@@ -1221,16 +1221,18 @@
 
   @include breakpoint('xlarge') {
     .m-article-header__text {
-      max-width: colspan(14, xlarge);
+      max-width: colspan(14, 'xlarge');
       z-index: 1;
     }
     .m-article-header__text::before {
-      left: -50%;
+      left: -300%;
       margin-left: 0;
-      max-width: colspan(14, xlarge);
+      max-width: colspan(50, 'xlarge');
     }
     .m-article-header__img {
-      flex: 0 0 auto;
+      height: 75vh;
+      right: 50%;
+      margin-right: -50vw;
     }
   }
 }

--- a/resources/views/components/molecules/_m-article-header----feature.blade.php
+++ b/resources/views/components/molecules/_m-article-header----feature.blade.php
@@ -1,5 +1,6 @@
 @if ($bgcolor ?? false)
     <style>
+        .{{ (isset($variation)) ? $variation : 'm-article-header--feature' }} .m-article-header__img::before,
         .{{ (isset($variation)) ? $variation : 'm-article-header--feature' }} .m-article-header__text,
         .{{ (isset($variation)) ? $variation : 'm-article-header--feature' }} .m-article-header__text::before {
             background-color: {{ $bgcolor }};


### PR DESCRIPTION
These changes include:
- the background color of the title/byline in the header reaches all the way to the screen edge in `xlarge` screen sizes
- fix scroll jump on mobile when passing sticky TOC
- the header image fades out/in on shrink/min-size:

https://github.com/user-attachments/assets/568621df-cab6-4b1c-aa99-2c1421f4aa60

