### PR TITLE
Remove digipub article create form

### DIFF
--- a/app/Http/Requests/Admin/DigitalPublicationArticleRequest.php
+++ b/app/Http/Requests/Admin/DigitalPublicationArticleRequest.php
@@ -14,6 +14,7 @@ class DigitalPublicationArticleRequest extends Request
     public function rulesForUpdate()
     {
         return [
+            'article_type' => 'required',
             'date' => 'required',
         ];
     }

--- a/app/Presenters/Admin/DigitalPublicationArticlePresenter.php
+++ b/app/Presenters/Admin/DigitalPublicationArticlePresenter.php
@@ -10,7 +10,7 @@ class DigitalPublicationArticlePresenter extends BasePresenter
 {
     public function getCanonicalUrl()
     {
-        if ($this->entity->type === DigitalPublicationArticleType::Grouping) {
+        if ($this->entity->article_type === DigitalPublicationArticleType::Grouping) {
             return route(
                 'collection.publications.digital-publications.showListing',
                 [
@@ -84,7 +84,7 @@ class DigitalPublicationArticlePresenter extends BasePresenter
         $descendants = $entity->descendants;
 
         $filteredDescendants = $descendants->filter(function ($descendant) {
-            return $descendant->type !== DigitalPublicationArticleType::Grouping;
+            return $descendant->article_type !== DigitalPublicationArticleType::Grouping;
         });
 
         return $filteredDescendants->count();

--- a/app/Presenters/Admin/DigitalPublicationPresenter.php
+++ b/app/Presenters/Admin/DigitalPublicationPresenter.php
@@ -51,7 +51,7 @@ class DigitalPublicationPresenter extends BasePresenter
         if (!isset($this->articles[$type])) {
             $this->articles[$type] = $this->articles['all']
                 ->filter(function ($article) use ($type) {
-                    return $article->type->value === $type;
+                    return $article->article_type->value === $type;
                 })
                 ->values();
         }

--- a/resources/views/admin/digitalPublications/articles/create.blade.php
+++ b/resources/views/admin/digitalPublications/articles/create.blade.php
@@ -1,8 +1,0 @@
-@include('twill::partials.create')
-
-@formField('select', [
-    'name' => 'article_type',
-    'label' => 'Type',
-    'placeholder' => 'Select a type',
-    'options' => $types,
-])

--- a/resources/views/admin/partials/featured-related.blade.php
+++ b/resources/views/admin/partials/featured-related.blade.php
@@ -61,7 +61,7 @@
             <ol style="margin: 1em 0; padding-left: 40px">
                 @foreach($autoRelated as $related)
                     <li style="list-style-type: decimal; margin-bottom: 0.5em">
-                        {!! Str::title($related->present()->type) . (Str::title($related->present()->type) ? ":" : "") !!} <a href="{{$related->admin_edit_url}}">{{ $related->title }}</a>
+                        {!! Str::title($related->present()->articleType) . (Str::title($related->present()->articleType) ? ":" : "") !!} <a href="{{$related->admin_edit_url}}">{{ $related->title }}</a>
                     </li>
                 @endforeach
             </ol>

--- a/resources/views/components/molecules/_m-digipub-title-bar.blade.php
+++ b/resources/views/components/molecules/_m-digipub-title-bar.blade.php
@@ -6,7 +6,7 @@ use Illuminate\Support\Str;
   @if ($item->children && count($item->children) >= 1)
   <a href="{{ $item->present()->url }}" class="f-link">
     <h2 class="title {{ $titleFont ?? 'f-list-2' }}" id="{{ isset($id) ? $id : Str::snake(strip_tags($item->present()->title), '-') }}">{!! $item->present()->title !!}</h2>
-      <span class="link">{{ 'View all ' . $item->present()->type }}
+      <span class="link">{{ 'View all ' . $item->present()->articleType }}
         <span aria-hidden="true">&rsaquo;</span>
       </span>
     </a>

--- a/resources/views/components/organisms/_o-table-of-contents.blade.php
+++ b/resources/views/components/organisms/_o-table-of-contents.blade.php
@@ -4,10 +4,10 @@
             if (isset($currentArticle)) {
                 $isExpanded = $currentArticle->parent === $item || $currentArticle->present()->isArticleInTree($item->children);
             } else {
-                if ($item->type === App\Enums\DigitalPublicationArticleType::Grouping) {
+                if ($item->article_type === App\Enums\DigitalPublicationArticleType::Grouping) {
 
                     $hasGroupingAncestor = $item->ancestors->contains(function ($ancestor) {
-                        return $ancestor->type === App\Enums\DigitalPublicationArticleType::Grouping;
+                        return $ancestor->article_type === App\Enums\DigitalPublicationArticleType::Grouping;
                     });
                     $isExpanded = !$hasGroupingAncestor;
                 } else {

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -13,8 +13,8 @@ $pClass = preg_replace('/Controller/i','',$pClass);
 $pClass = strtolower(preg_replace('/@/i','-',$pClass));
 
 $pType = '';
-if (isset($item) && isset($item->type) && isset($item->type->name)) {
-    $pType = 'p-t-' . Str::kebab($item->type->name);
+if (isset($item) && isset($item->article_type) && isset($item->article_type->name)) {
+    $pType = 'p-t-' . Str::kebab($item->article_type->name);
 }
 @endphp
 <!DOCTYPE html>

--- a/resources/views/site/digitalPublicationArticleDetail.blade.php
+++ b/resources/views/site/digitalPublicationArticleDetail.blade.php
@@ -17,7 +17,7 @@
 @endif
 
 <article class="o-article">
-    @if ($item->type == DigitalPublicationArticleType::Contributions)
+    @if ($item->article_type == DigitalPublicationArticleType::Contributions)
         @component('components.molecules._m-article-header----digital-publication-article')
             @slot('title', $item->present()->title)
             @slot('title_display', $item->present()->title_display)
@@ -39,7 +39,7 @@
         @endcomponent
     </div>
 
-    @if ($item->type != DigitalPublicationArticleType::Contributions && $item->type != DigitalPublicationArticleType::Entry)
+    @if ($item->article_type != DigitalPublicationArticleType::Contributions && $item->article_type != DigitalPublicationArticleType::Entry)
         @component('components.molecules._m-article-header')
             @slot('headerType', 'generic')
             @slot('title', $item->present()->title)
@@ -51,7 +51,7 @@
         {{-- Intentionally left blank for layout --}}
     </div>
 
-    @if ($item->type !== DigitalPublicationArticleType::Entry)
+    @if ($item->article_type !== DigitalPublicationArticleType::Entry)
         <div class="m-article-header__text u-show@large+">
             @component('components.atoms._title')
                 @slot('tag', 'h1')
@@ -74,7 +74,7 @@
     @endif
 
     <div class="o-article__body o-blocks o-blocks--with-sidebar">
-        @switch ($item->type)
+        @switch ($item->article_type)
             @case (DigitalPublicationArticleType::Contributions)
             @case (DigitalPublicationArticleType::Entry)
                 @if ($item->showAuthorsWithLinks())
@@ -89,7 +89,7 @@
         @endswitch
 
         @php
-        switch ($item->type) {
+        switch ($item->article_type) {
             case DigitalPublicationArticleType::Contributions:
             case DigitalPublicationArticleType::Entry:
                 global $_collectedReferences;

--- a/resources/views/site/digitalPublicationDetail.blade.php
+++ b/resources/views/site/digitalPublicationDetail.blade.php
@@ -1,7 +1,3 @@
-@php
-    use App\Enums\DigitalPublicationArticleType;
-@endphp
-
 @extends('layouts.app')
 
 @section('content')
@@ -98,7 +94,7 @@
                                                 @component('components.molecules._m-listing----digital-publication-article')
                                                     @slot('href', $item->present()->url)
                                                     @slot('image', $item->imageFront('hero'))
-                                                    @slot('type', $item->present()->type)
+                                                    @slot('type', $item->present()->articleType)
                                                     @slot('title', $item->present()->title)
                                                     @slot('title_display', $item->present()->title_display)
                                                     @slot('list_description', $item->present()->list_description)
@@ -125,7 +121,7 @@
                             @else
                                 @component('components.molecules._m-showcase')
                                     @slot('variation', 'showcase--digital-publication')
-                                    @slot('tag', $topLevelArticle->present()->type)
+                                    @slot('tag', $topLevelArticle->present()->articleType)
                                     @slot('title', $topLevelArticle->present()->title_display ?? $topLevelArticle->present()->title)
                                     @slot('author_display', $topLevelArticle->showAuthors())
                                     @slot('description', $topLevelArticle->present()->list_description)
@@ -176,7 +172,7 @@
                                     @component('components.molecules._m-listing----digital-publication-article')
                                         @slot('href', $item->present()->url)
                                         @slot('image', $item->imageFront('hero'))
-                                        @slot('type', $item->present()->type)
+                                        @slot('type', $item->present()->articleType)
                                         @slot('title', $item->present()->title)
                                         @slot('title_display', $item->present()->title_display)
                                         @slot('list_description', $item->present()->list_description)
@@ -287,7 +283,7 @@
                                                 @slot('cols_medium','4')
                                                 @slot('cols_large','4')
                                                 @slot('cols_xlarge','4')
-                                        
+
                                                 @foreach ($item->children as $child)
                                                     @component('components.molecules._m-listing----digital-publication-article-entry')
                                                         @slot('href', $child->present()->url)
@@ -371,7 +367,7 @@
                                             @slot('variation', 'm-listing--seventy-thirty')
                                             @slot('href', $item->present()->url)
                                             @slot('image', $item->imageFront('hero'))
-                                            @slot('type', $item->present()->type)
+                                            @slot('type', $item->present()->articleType)
                                             @slot('title', $item->present()->title)
                                             @slot('title_display', $item->present()->title_display)
                                             @slot('list_description', $item->present()->list_description)
@@ -427,14 +423,14 @@
                                                 'variation' => 'm-title-bar--compact m-title-bar--no-hr',
                                             ])
                                                 @slot('item', $item)
-                                                {!! $item->present()->type !!}
+                                                {!! $item->present()->articleType !!}
                                             @endcomponent
                                         @else
                                             @component('components.molecules._m-listing----digital-publication-article')
                                                 @slot('variation', 'm-listing--title-only')
                                                 @slot('href', $item->present()->url)
                                                 @slot('image', $item->imageFront('hero'))
-                                                @slot('type', $item->present()->type)
+                                                @slot('type', $item->present()->articleType)
                                                 @slot('title', $item->present()->title)
                                                 @slot('title_display', $item->present()->title_display)
                                                 @slot('list_description', $item->present()->list_description)
@@ -459,7 +455,7 @@
                                         'variation' => 'm-title-bar--compact m-title-bar--no-hr',
                                     ])
                                         @slot('item', $topLevelArticle)
-                                        {!! $topLevelArticle->present()->type !!}
+                                        {!! $topLevelArticle->present()->articleType !!}
                                     @endcomponent
                                 @endif
 
@@ -497,7 +493,7 @@
                                 @component('components.molecules._m-listing----digital-publication-article')
                                     @slot('href', $item->present()->url)
                                     @slot('image', $item->imageFront('hero'))
-                                    @slot('type', $item->present()->type)
+                                    @slot('type', $item->present()->articleType)
                                     @slot('title', $item->present()->title)
                                     @slot('title_display', $item->present()->title_display)
                                     @slot('list_description', $item->present()->list_description)


### PR DESCRIPTION
This work removes the digital publication article create form (and makes the `article_type` field required in the rules for updating). Also, I replaced remaining instances of `type` with `article_type`/`articleType`.