### PR TITLE
Make fields conditional on article_type

### DIFF
--- a/resources/views/admin/digitalPublications/articles/form.blade.php
+++ b/resources/views/admin/digitalPublications/articles/form.blade.php
@@ -25,14 +25,14 @@
 @stop
 
 @section('fieldsets')
-    @formConnectedFields([
-        'fieldName' => 'article_type',
-        'fieldValues' => 'grouping',
-        'renderForBlocks' => false,
+    @formFieldset([
+        'id' => 'article-type-fields',
+        'title' => 'Article type fields',
     ])
-        @formFieldset([
-            'id' => 'fields-for-type-grouping',
-            'title' => 'Grouping fields',
+        @formConnectedFields([
+            'fieldName' => 'article_type',
+            'fieldValues' => 'grouping',
+            'renderForBlocks' => false,
         ])
             @formField('select', [
                 'name' => 'listing_display',
@@ -74,17 +74,12 @@
                 'name' => 'grouping_mobile_hero',
                 'note' => 'Minimum image width 2000px'
             ])
-        @endformFieldset
-    @endformConnectedFields
+        @endformConnectedFields
 
-    @formConnectedFields([
-        'fieldName' => 'article_type',
-        'fieldValues' => 'entry',
-        'renderForBlocks' => false,
-    ])
-        @formFieldset([
-            'id' => 'fields-for-type-entry',
-            'title' => 'Entry fields',
+        @formConnectedFields([
+            'fieldName' => 'article_type',
+            'fieldValues' => 'entry',
+            'renderForBlocks' => false,
         ])
             @formField('medias', [
                 'with_multiple' => false,
@@ -102,38 +97,6 @@
                 'note' => 'Minimum image width 2000px'
             ])
 
-            @component('twill::partials.form.utils._columns')
-                @slot('left')
-                    @formField('checkbox', [
-                        'name' => 'hide_title',
-                        'label' => 'Hide title in listing view',
-                    ])
-                @endslot
-
-                @slot('right')
-                    @formField('checkbox', [
-                        'name' => 'suppress_listing',
-                        'label' => 'Hide from listing view',
-                    ])
-                @endslot
-            @endcomponent
-
-            @formField('input', [
-                'name' => 'label',
-                'label' => 'Article label',
-                'note' => 'Used in the "eyebrow" of cards on the publication page',
-            ])
-
-            @formField('wysiwyg', [
-                'name' => 'list_description',
-                'label' => 'List description',
-                'maxlength' => 255,
-                'note' => 'Max 255 characters. Will be used on the main landing, search, and social media.',
-                'toolbarOptions' => [
-                    'italic',
-                ],
-            ])
-
             @formField('input', [
                 'name' => 'author_display',
                 'label' => 'Author display',
@@ -148,68 +111,12 @@
                 'max' => 10,
                 'note' => 'On Entry type articles, authorship is prepended with "Entry by"',
             ])
+        @endformConnectedFields
 
-            @formField('wysiwyg', [
-                'name' => 'cite_as',
-                'label' => 'How to Cite',
-                'toolbarOptions' => [
-                    'italic',
-                ],
-            ])
-
-            @formField('wysiwyg', [
-                'name' => 'references',
-                'label' => 'References',
-                'toolbarOptions' => [
-                    'italic', 'link', 'list-ordered', 'list-unordered',
-                ],
-            ])
-
-            @formField('block_editor', [
-                'blocks' => BlockHelpers::getBlocksForEditor([
-                    '360_embed',
-                    '360_modal',
-                    '3d_embed',
-                    '3d_model',
-                    '3d_tour',
-                    'ranged_accordion',
-                    'artwork',
-                    'audio_player',
-                    'button',
-                    'citation',
-                    'digital_label',
-                    'gallery_new',
-                    'hr',
-                    'image',
-                    'image_slider',
-                    'layered_image_viewer',
-                    'links-bar',
-                    'list',
-                    'media_embed',
-                    'membership_banner',
-                    'mirador_embed',
-                    'mirador_modal',
-                    'mobile_app',
-                    'paragraph',
-                    'quote',
-                    'split_block',
-                    'table',
-                    'tombstone',
-                    'tour_stop',
-                    'video',
-                ])
-            ])
-        @endformFieldset
-    @endformConnectedFields
-
-    @formConnectedFields([
-        'fieldName' => 'article_type',
-        'fieldValues' => ['about', 'text', 'work'],
-        'renderForBlocks' => false,
-    ])
-        @formFieldset([
-            'id' => 'fields-for-type-other',
-            'title' => 'Article fields',
+        @formConnectedFields([
+            'fieldName' => 'article_type',
+            'fieldValues' => ['about', 'text', 'work'],
+            'renderForBlocks' => false,
         ])
             @formField('medias', [
                 'with_multiple' => false,
@@ -227,6 +134,26 @@
                 'note' => 'Minimum image width 2000px'
             ])
 
+            @formField('input', [
+                'name' => 'author_display',
+                'label' => 'Author display',
+            ])
+
+            @formField('browser', [
+                'routePrefix' => 'collection',
+                'moduleName' => 'authors',
+                'name' => 'authors',
+                'label' => 'Authors',
+                'max' => 10,
+            ])
+        @endformConnectedFields
+
+        @formConnectedFields([
+            'fieldName' => 'article_type',
+            'fieldValues' => 'grouping',
+            'isEqual' => false,
+            'renderForBlocks' => false,
+        ])
             @component('twill::partials.form.utils._columns')
                 @slot('left')
                     @formField('checkbox', [
@@ -257,19 +184,6 @@
                 'toolbarOptions' => [
                     'italic',
                 ],
-            ])
-
-            @formField('input', [
-                'name' => 'author_display',
-                'label' => 'Author display',
-            ])
-
-            @formField('browser', [
-                'routePrefix' => 'collection',
-                'moduleName' => 'authors',
-                'name' => 'authors',
-                'label' => 'Authors',
-                'max' => 10,
             ])
 
             @formField('wysiwyg', [
@@ -322,8 +236,8 @@
                     'video',
                 ])
             ])
-        @endformFieldset
-    @endformConnectedFields
+        @endformConnectedFields
+    @endformFieldset
 
     @include('admin.partials.meta')
 @stop

--- a/resources/views/admin/digitalPublications/articles/form.blade.php
+++ b/resources/views/admin/digitalPublications/articles/form.blade.php
@@ -15,141 +15,12 @@
         'note' => 'Required',
     ])
 
-    @formField('medias', [
-        'with_multiple' => false,
-        'no_crop' => false,
-        'label' => 'Hero image',
-        'name' => 'hero',
-        'note' => 'Minimum image width 3000px'
-    ])
-
-    @formField('medias', [
-        'with_multiple' => false,
-        'no_crop' => false,
-        'label' => 'Mobile hero image',
-        'name' => 'mobile_hero',
-        'note' => 'Minimum image width 2000px'
-    ])
-
     @formField('select', [
         'name' => 'article_type',
         'label' => 'Type',
         'placeholder' => 'Select a type',
         'default' => 'text',
         'options' => $types,
-    ])
-
-    @component('twill::partials.form.utils._columns')
-        @slot('left')
-            @formField('checkbox', [
-                'name' => 'hide_title',
-                'label' => 'Hide title in listing view',
-            ])
-        @endslot
-
-        @slot('right')
-            @formField('checkbox', [
-                'name' => 'suppress_listing',
-                'label' => 'Hide from listing view',
-            ])
-        @endslot
-    @endcomponent
-
-    @formField('select', [
-        'name' => 'listing_display',
-        'label' => 'Listing display',
-        'placeholder' => 'Select a listing display',
-        'default' => 'default',
-        'options' => [
-            ['value' => 'feature', 'label' => 'Feature'],
-            ['value' => '3-across', 'label' => '3-Across'],
-            ['value' => 'entries', 'label' => 'Entries'],
-            ['value' => 'group_entries', 'label' => 'Group of Entries'],
-            ['value' => 'list', 'label' => 'List view'],
-            ['value' => 'simple_list', 'label' => 'Text list view'],
-        ],
-    ])
-
-    @formField('input', [
-        'name' => 'label',
-        'label' => 'Article label',
-        'note' => 'Used in the "eyebrow" of cards on the publication page',
-    ])
-
-    @formField('wysiwyg', [
-        'name' => 'list_description',
-        'label' => 'List description',
-        'maxlength' => 255,
-        'note' => 'Max 255 characters. Will be used on the main landing, search, and social media.',
-        'toolbarOptions' => [
-            'italic',
-        ],
-    ])
-
-    @formField('input', [
-        'name' => 'author_display',
-        'label' => 'Author display',
-        'note' => 'On Entry type articles, authorship is prepended with "Entry by"',
-    ])
-
-    @formField('browser', [
-        'routePrefix' => 'collection',
-        'moduleName' => 'authors',
-        'name' => 'authors',
-        'label' => 'Authors',
-        'max' => 10,
-        'note' => 'On Entry type articles, authorship is prepended with "Entry by"',
-    ])
-
-    @formField('wysiwyg', [
-        'name' => 'cite_as',
-        'label' => 'How to Cite',
-        'toolbarOptions' => [
-            'italic',
-        ],
-    ])
-
-    @formField('wysiwyg', [
-        'name' => 'references',
-        'label' => 'References',
-        'toolbarOptions' => [
-            'italic', 'link', 'list-ordered', 'list-unordered',
-        ],
-    ])
-
-    @formField('block_editor', [
-        'blocks' => BlockHelpers::getBlocksForEditor([
-            '360_embed',
-            '360_modal',
-            '3d_embed',
-            '3d_model',
-            '3d_tour',
-            'ranged_accordion',
-            'artwork',
-            'audio_player',
-            'button',
-            'citation',
-            'digital_label',
-            'gallery_new',
-            'hr',
-            'image',
-            'image_slider',
-            'layered_image_viewer',
-            'links-bar',
-            'list',
-            'media_embed',
-            'membership_banner',
-            'mirador_embed',
-            'mirador_modal',
-            'mobile_app',
-            'paragraph',
-            'quote',
-            'split_block',
-            'table',
-            'tombstone',
-            'tour_stop',
-            'video',
-        ])
     ])
 @stop
 
@@ -163,6 +34,21 @@
             'id' => 'fields-for-type-grouping',
             'title' => 'Grouping fields',
         ])
+            @formField('select', [
+                'name' => 'listing_display',
+                'label' => 'Listing display',
+                'placeholder' => 'Select a listing display',
+                'default' => 'default',
+                'options' => [
+                    ['value' => 'feature', 'label' => 'Feature'],
+                    ['value' => '3-across', 'label' => '3-Across'],
+                    ['value' => 'entries', 'label' => 'Entries'],
+                    ['value' => 'group_entries', 'label' => 'Group of Entries'],
+                    ['value' => 'list', 'label' => 'List view'],
+                    ['value' => 'simple_list', 'label' => 'Text list view'],
+                ],
+            ])
+
             @formField('wysiwyg', [
                 'name' => 'grouping_description',
                 'label' => 'Description',
@@ -176,7 +62,7 @@
             @formField('medias', [
                 'with_multiple' => false,
                 'no_crop' => false,
-                'label' => 'Hero image',
+                'label' => 'Grouping image',
                 'name' => 'grouping_hero',
                 'note' => 'Minimum image width 3000px'
             ])
@@ -184,9 +70,257 @@
             @formField('medias', [
                 'with_multiple' => false,
                 'no_crop' => false,
-                'label' => 'Mobile hero image',
+                'label' => 'Mobile grouping image',
                 'name' => 'grouping_mobile_hero',
                 'note' => 'Minimum image width 2000px'
+            ])
+        @endformFieldset
+    @endformConnectedFields
+
+    @formConnectedFields([
+        'fieldName' => 'article_type',
+        'fieldValues' => 'entry',
+        'renderForBlocks' => false,
+    ])
+        @formFieldset([
+            'id' => 'fields-for-type-entry',
+            'title' => 'Entry fields',
+        ])
+            @formField('medias', [
+                'with_multiple' => false,
+                'no_crop' => false,
+                'label' => 'Listing image',
+                'name' => 'hero',
+                'note' => 'Minimum image width 3000px'
+            ])
+
+            @formField('medias', [
+                'with_multiple' => false,
+                'no_crop' => false,
+                'label' => 'Mobile listing image',
+                'name' => 'mobile_hero',
+                'note' => 'Minimum image width 2000px'
+            ])
+
+            @component('twill::partials.form.utils._columns')
+                @slot('left')
+                    @formField('checkbox', [
+                        'name' => 'hide_title',
+                        'label' => 'Hide title in listing view',
+                    ])
+                @endslot
+
+                @slot('right')
+                    @formField('checkbox', [
+                        'name' => 'suppress_listing',
+                        'label' => 'Hide from listing view',
+                    ])
+                @endslot
+            @endcomponent
+
+            @formField('input', [
+                'name' => 'label',
+                'label' => 'Article label',
+                'note' => 'Used in the "eyebrow" of cards on the publication page',
+            ])
+
+            @formField('wysiwyg', [
+                'name' => 'list_description',
+                'label' => 'List description',
+                'maxlength' => 255,
+                'note' => 'Max 255 characters. Will be used on the main landing, search, and social media.',
+                'toolbarOptions' => [
+                    'italic',
+                ],
+            ])
+
+            @formField('input', [
+                'name' => 'author_display',
+                'label' => 'Author display',
+                'note' => 'On Entry type articles, authorship is prepended with "Entry by"',
+            ])
+
+            @formField('browser', [
+                'routePrefix' => 'collection',
+                'moduleName' => 'authors',
+                'name' => 'authors',
+                'label' => 'Authors',
+                'max' => 10,
+                'note' => 'On Entry type articles, authorship is prepended with "Entry by"',
+            ])
+
+            @formField('wysiwyg', [
+                'name' => 'cite_as',
+                'label' => 'How to Cite',
+                'toolbarOptions' => [
+                    'italic',
+                ],
+            ])
+
+            @formField('wysiwyg', [
+                'name' => 'references',
+                'label' => 'References',
+                'toolbarOptions' => [
+                    'italic', 'link', 'list-ordered', 'list-unordered',
+                ],
+            ])
+
+            @formField('block_editor', [
+                'blocks' => BlockHelpers::getBlocksForEditor([
+                    '360_embed',
+                    '360_modal',
+                    '3d_embed',
+                    '3d_model',
+                    '3d_tour',
+                    'ranged_accordion',
+                    'artwork',
+                    'audio_player',
+                    'button',
+                    'citation',
+                    'digital_label',
+                    'gallery_new',
+                    'hr',
+                    'image',
+                    'image_slider',
+                    'layered_image_viewer',
+                    'links-bar',
+                    'list',
+                    'media_embed',
+                    'membership_banner',
+                    'mirador_embed',
+                    'mirador_modal',
+                    'mobile_app',
+                    'paragraph',
+                    'quote',
+                    'split_block',
+                    'table',
+                    'tombstone',
+                    'tour_stop',
+                    'video',
+                ])
+            ])
+        @endformFieldset
+    @endformConnectedFields
+
+    @formConnectedFields([
+        'fieldName' => 'article_type',
+        'fieldValues' => ['about', 'text', 'work'],
+        'renderForBlocks' => false,
+    ])
+        @formFieldset([
+            'id' => 'fields-for-type-other',
+            'title' => 'Article fields',
+        ])
+            @formField('medias', [
+                'with_multiple' => false,
+                'no_crop' => false,
+                'label' => 'Hero image',
+                'name' => 'hero',
+                'note' => 'Minimum image width 3000px'
+            ])
+
+            @formField('medias', [
+                'with_multiple' => false,
+                'no_crop' => false,
+                'label' => 'Mobile hero image',
+                'name' => 'mobile_hero',
+                'note' => 'Minimum image width 2000px'
+            ])
+
+            @component('twill::partials.form.utils._columns')
+                @slot('left')
+                    @formField('checkbox', [
+                        'name' => 'hide_title',
+                        'label' => 'Hide title in listing view',
+                    ])
+                @endslot
+
+                @slot('right')
+                    @formField('checkbox', [
+                        'name' => 'suppress_listing',
+                        'label' => 'Hide from listing view',
+                    ])
+                @endslot
+            @endcomponent
+
+            @formField('input', [
+                'name' => 'label',
+                'label' => 'Article label',
+                'note' => 'Used in the "eyebrow" of cards on the publication page',
+            ])
+
+            @formField('wysiwyg', [
+                'name' => 'list_description',
+                'label' => 'List description',
+                'maxlength' => 255,
+                'note' => 'Max 255 characters. Will be used on the main landing, search, and social media.',
+                'toolbarOptions' => [
+                    'italic',
+                ],
+            ])
+
+            @formField('input', [
+                'name' => 'author_display',
+                'label' => 'Author display',
+            ])
+
+            @formField('browser', [
+                'routePrefix' => 'collection',
+                'moduleName' => 'authors',
+                'name' => 'authors',
+                'label' => 'Authors',
+                'max' => 10,
+            ])
+
+            @formField('wysiwyg', [
+                'name' => 'cite_as',
+                'label' => 'How to Cite',
+                'toolbarOptions' => [
+                    'italic',
+                ],
+            ])
+
+            @formField('wysiwyg', [
+                'name' => 'references',
+                'label' => 'References',
+                'toolbarOptions' => [
+                    'italic', 'link', 'list-ordered', 'list-unordered',
+                ],
+            ])
+
+            @formField('block_editor', [
+                'blocks' => BlockHelpers::getBlocksForEditor([
+                    '360_embed',
+                    '360_modal',
+                    '3d_embed',
+                    '3d_model',
+                    '3d_tour',
+                    'ranged_accordion',
+                    'artwork',
+                    'audio_player',
+                    'button',
+                    'citation',
+                    'digital_label',
+                    'gallery_new',
+                    'hr',
+                    'image',
+                    'image_slider',
+                    'layered_image_viewer',
+                    'links-bar',
+                    'list',
+                    'media_embed',
+                    'membership_banner',
+                    'mirador_embed',
+                    'mirador_modal',
+                    'mobile_app',
+                    'paragraph',
+                    'quote',
+                    'split_block',
+                    'table',
+                    'tombstone',
+                    'tour_stop',
+                    'video',
+                ])
             ])
         @endformFieldset
     @endformConnectedFields


### PR DESCRIPTION
This change puts all but the `title_display`, `date`, and `article_type` fields in separate type-dependent fieldsets: "Entry fields", "Grouping fields", and "Article fields" (for the remaining article types).