### PR TITLE
Set correct default article_type in digipub article model

### DIFF
--- a/app/Models/DigitalPublicationArticle.php
+++ b/app/Models/DigitalPublicationArticle.php
@@ -67,7 +67,7 @@ class DigitalPublicationArticle extends AbstractModel implements Sortable
 
     public $attributes = [
         'published' => false,
-        'article_type' => 'entry',
+        'article_type' => 'text',
     ];
 
     public $mediasParams = [


### PR DESCRIPTION
The default article_type should be "text"/Contribution instead of "entry"/Entry.