### PR TITLE
Digipub contrast text color in header

### DIFF
--- a/frontend/js/behaviors/core/contrastText.js
+++ b/frontend/js/behaviors/core/contrastText.js
@@ -1,0 +1,14 @@
+import { textContrast } from "text-contrast"
+
+const contrastText = function(container) {
+  function _init() {
+    let lightOrDark = textContrast.isLightOrDark(container.dataset.backgroundColor);
+    container.classList.add(`s-${lightOrDark}-background`);
+  }
+
+  this.init = function() {
+    _init();
+  }
+}
+
+export default contrastText;

--- a/frontend/js/behaviors/core/index.js
+++ b/frontend/js/behaviors/core/index.js
@@ -65,3 +65,4 @@ export { default as editorialHeader } from './editorialHeader';
 export { default as loadRelatedSidebar } from './loadRelatedSidebar';
 export { default as rangedAccordion } from './rangedAccordion';
 export { default as stickyDigitalPublicationHeader } from './stickyDigitalPublicationHeader';
+export { default as contrastText } from './contrastText';

--- a/frontend/scss/_importsCore.scss
+++ b/frontend/scss/_importsCore.scss
@@ -194,3 +194,4 @@
 @import 'state/s-closer-look-scroll-blocked';
 @import 'state/s-closer-look-footer-stuck';
 @import 'state/s-layered-image-viewer-active';
+@import 'state/s-contrast-text';

--- a/frontend/scss/molecules/_m-article-header.scss
+++ b/frontend/scss/molecules/_m-article-header.scss
@@ -1078,17 +1078,11 @@
 
     white-space: normal;
 
-    >a {
-      color: $color__white !important;
-
-      &:hover {
-        color: $color__white !important;
-        text-decoration: underline !important;
-      }
+    >a:hover {
+      text-decoration: underline !important;
     }
 
     .f-headline-editorial {
-      color: $color__white !important;
       @include untuck();
     }
   }
@@ -1409,7 +1403,6 @@
   }
 
   .title {
-    color: $color__white;
     z-index: 4;
   }
 }

--- a/frontend/scss/organisms/_o-article__primary-actions.scss
+++ b/frontend/scss/organisms/_o-article__primary-actions.scss
@@ -302,7 +302,11 @@
     }
 
     a {
-      color: $color__link--publications;
+      transition: color 1s;
+
+      .is-sidebar-fixed & {
+        color: $color__black !important;
+      }
     }
 
     a:hover,

--- a/frontend/scss/state/_s-contrast-text.scss
+++ b/frontend/scss/state/_s-contrast-text.scss
@@ -1,0 +1,11 @@
+.contrast-text {
+  .s-light-background ~ * &,
+  .s-light-background & {
+    color: $color__black !important;
+  }
+
+  .s-dark-background ~ * &,
+  .s-dark-background & {
+    color: $color__white !important;
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -11962,6 +11962,11 @@
         }
       }
     },
+    "text-contrast": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/text-contrast/-/text-contrast-1.0.2.tgz",
+      "integrity": "sha512-tTWdDxZavzt7sPaKG7bR4RfXmyaWJodNhg1vzQVxzpXfmGSa4DIG9zYJ1PYuUObyae7ErSrPiUA8hRlwafmbow=="
+    },
     "text-hex": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/text-hex/-/text-hex-1.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "read-pkg-up": "^3.0.0",
     "readline-sync": "^1.4.10",
     "sass": "^1.42.1",
+    "text-contrast": "^1.0.2",
     "video.js": "^7.14.3",
     "videojs-event-tracking": "^1.0.2",
     "webpack": "^4.39.3",

--- a/resources/views/components/molecules/_m-article-actions----digital-publication.blade.php
+++ b/resources/views/components/molecules/_m-article-actions----digital-publication.blade.php
@@ -5,7 +5,7 @@
     </button>
 
     <div class="m-article-actions--publication__logo u-show@large+">
-        <a href="{!! $digitalPublication->present()->getCanonicalUrl() !!}">
+        <a href="{!! $digitalPublication->present()->getCanonicalUrl() !!}" class="contrast-text">
             {!! $digitalPublication->title_display ?? $digitalPublication->title !!}
         </a>
     </div>

--- a/resources/views/components/molecules/_m-article-header----digital-publication-article.blade.php
+++ b/resources/views/components/molecules/_m-article-header----digital-publication-article.blade.php
@@ -7,7 +7,11 @@
     </style>
 @endif
 
-<header class="m-article-header m-article-header--feature m-article-header--digital-publication-article">
+<header
+    class="m-article-header m-article-header--feature m-article-header--digital-publication-article"
+    data-behavior="contrastText"
+    data-background-color="{{ $bgcolor }}"
+>
     <div class="m-article-header__img">
         @if ($img)
             @component('components.atoms._img')

--- a/resources/views/components/molecules/_m-article-header----feature.blade.php
+++ b/resources/views/components/molecules/_m-article-header----feature.blade.php
@@ -9,7 +9,8 @@
 @endif
 <{{ $tag ?? 'header' }}
     class="m-article-header m-article-header--feature{{ (isset($variation)) ? ' '.$variation : '' }}"
-    data-behavior="blurMyBackground stickyDigitalPublicationHeader"
+    data-behavior="blurMyBackground stickyDigitalPublicationHeader contrastText"
+    data-background-color="{{ $bgcolor }}"
 >
     <div class="m-article-header__img"{{ (isset($variation) && $variation != 'm-article-header--digital-publication') ? ' data-blur-img' : '' }}>
         @if ($img)
@@ -42,12 +43,13 @@
                     @slot('itemprop','name')
                     @slot('title', $title)
                     @slot('title_display', $title_display ?? null)
+                    @slot('variation', 'contrast-text')
                 @endcomponent
             @if (isset($title_href))
                 </a>
             @endif
             @if (isset($subtitle_display))
-                <h2 class="subtitle f-headline-editorial">
+                <h2 class="subtitle f-headline-editorial contrast-text">
                     {!! $subtitle_display !!}
                 </h2>
             @endif

--- a/resources/views/site/digitalPublicationArticleDetail.blade.php
+++ b/resources/views/site/digitalPublicationArticleDetail.blade.php
@@ -18,6 +18,7 @@
 <article class="o-article">
     @if ($item->article_type == DigitalPublicationArticleType::Contributions)
         @component('components.molecules._m-article-header----digital-publication-article')
+            @slot('bgcolor', $bgcolor)
             @slot('title', $item->present()->title)
             @slot('title_display', $item->present()->title_display)
             @slot('pub_title', $item->digitalPublication->present()->title)
@@ -60,6 +61,7 @@
                 @slot('itemprop', 'name')
                 @slot('title', $item->present()->title)
                 @slot('title_display', $item->present()->title_display ?? null)
+                @slot('variation', 'contrast-text')
             @endcomponent
         </div>
     @endif


### PR DESCRIPTION
This change includes installing a new [text-contrast](https://www.npmjs.com/package/text-contrast) package that uses [WCAG's recommended procedure](https://www.w3.org/WAI/WCAG21/Techniques/general/G18#procedure) for determining appropriate color contrast. I then used this package to create a `contrastText` behavior that set's the specified text to either black or white based on the provided background color.