### PR TITLE
Bump My Museum Tour version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8575,7 +8575,7 @@
       }
     },
     "my-museum-tour-builder": {
-      "version": "git+https://github.com/art-institute-of-chicago/my-museum-tour.git#561741128694d3b0a3ab98a2e1b2bf24b6077f07",
+      "version": "git+https://github.com/art-institute-of-chicago/my-museum-tour.git#bef1cdbb2db2c65b912cfb6a93290935864c47bf",
       "from": "git+https://github.com/art-institute-of-chicago/my-museum-tour.git#semver:^1.0.0",
       "requires": {
         "@area17/a17-helpers": "^0.6.7",


### PR DESCRIPTION
I [tagged an updated patch](https://github.com/art-institute-of-chicago/my-museum-tour/tree/1.16.1) for MMT, so I'm bumping the version here. This confirms it is the correct commit:
```
Asset-3076:my-museum-tour zgarwo$ git show-ref -s 1.16.1
bef1cdbb2db2c65b912cfb6a93290935864c47bf
```