### PR TITLE
Set paragraph widths based on screen widths

### DIFF
--- a/frontend/scss/pages/_p-issuearticle-show.scss
+++ b/frontend/scss/pages/_p-issuearticle-show.scss
@@ -59,6 +59,12 @@
 
   .o-blocks > p {
     @include untuck();
+
+    @each $name in ('large', 'xlarge') {
+      @include breakpoint('#{$name}') {
+        width: colspan(33, '#{$name}');
+      }
+    }
   }
 
   &.s-sans-serif-loaded .o-blocks>p:not([class*=f-]),

--- a/frontend/scss/pages/_p-issuearticle-show.scss
+++ b/frontend/scss/pages/_p-issuearticle-show.scss
@@ -59,12 +59,6 @@
 
   .o-blocks > p {
     @include untuck();
-
-    @each $name in ('large', 'xlarge') {
-      @include breakpoint('#{$name}') {
-        width: colspan(33, '#{$name}');
-      }
-    }
   }
 
   &.s-sans-serif-loaded .o-blocks>p:not([class*=f-]),
@@ -204,10 +198,31 @@
     padding-top: 0;
     margin-top: 60px;
 
-    @include breakpoint('large+') {
-      margin-left: calc(300px + colspan(2, large));
-      max-width: 900px;
-      width: colspan(46, large);
+
+  .o-article__body .p--linked {
+    @include breakpoint('small-') {
+      padding-right: 0;
+      .p--linked__text {
+        width: 100%;
+      }
+      .p--linked__ref {
+        display: none;
+      }
+    }
+    @include breakpoint('medium') {
+      .p--linked__text {
+        width: 88%;
+      }
+    }
+    @include breakpoint('large') {
+      .p--linked__text {
+        width: colspan(33, 'large');
+      }
+    }
+    @include breakpoint('xlarge') {
+      .p--linked__text {
+        width: 73.5%
+      }
     }
   }
 

--- a/frontend/scss/pages/_p-issuearticle-show.scss
+++ b/frontend/scss/pages/_p-issuearticle-show.scss
@@ -205,11 +205,6 @@
     }
   }
 
-  .o-article__body .p--linked {
-    margin-right: 1.5em;
-    padding-right: 1em;
-  }
-
   .o-article__primary-actions--digital-publication {
     @include breakpoint('large+') {
       max-width: 300px;


### PR DESCRIPTION
This change sets the paragraph widths based on the breakpoint. Also, it hides the paragraph numbers for small and x-small breakpoints.