### PR TITLE
Gallery not visible as Entry lead image [PUB-275]

### DIFF
--- a/frontend/scss/setup/mixins/_other.scss
+++ b/frontend/scss/setup/mixins/_other.scss
@@ -120,18 +120,6 @@ Creates a load spinner.
   @return $string;
 }
 
-// To fix collapsing margins
-.clearfix {
-  &:before,&:after {
-    display:table;
-    content:"";
-    line-height:0;
-  }
-  &:after {
-    clear:both;
-  }
-}
-
 @mixin tucked-margin-top($font-obj, $distances, $single-bp: false) {
   $settings: false;
   $line-height: 0;

--- a/resources/views/components/organisms/_o-gallery----slider.blade.php
+++ b/resources/views/components/organisms/_o-gallery----slider.blade.php
@@ -1,5 +1,4 @@
 <div class="o-gallery o-gallery--slider{{ (isset($variation)) ? ' '.$variation : '' }}{{ empty($title) ? ' o-gallery----headerless' : '' }}">
-    <div class="clearfix"></div>
     @if (!empty($title))
         <h3 id="{{ Str::slug(html_entity_decode($title)) }}" class="o-gallery__title f-module-title-2">{!! $title !!}</h3>
     @endif


### PR DESCRIPTION
This clearfix fix was in place to help space out Video's on the homepage carousel a while ago.