### PR TITLE
Fix TOC width & margin

### DIFF
--- a/frontend/js/behaviors/core/stickySidebar.js
+++ b/frontend/js/behaviors/core/stickySidebar.js
@@ -200,6 +200,12 @@ const stickySidebar = function(container){
     }
   }
 
+  function _escape(event) {
+    if (overlayActive && event.keyCode === 27) {
+      triggerCustomEvent(document, 'stickySidebar:close');
+    }
+  }
+
   function _init() {
     window.addEventListener('scroll', handleScroll);
     window.addEventListener('resized', handleResize);
@@ -214,6 +220,7 @@ const stickySidebar = function(container){
     document.addEventListener('mediaQueryUpdated',_mediaQueryUpdated, false);
 
     window.addEventListener('hashchange', _hideSidebar, false);
+    window.addEventListener('keyup', _escape, false);
 
     handleResize();
     handleScroll();
@@ -231,6 +238,7 @@ const stickySidebar = function(container){
     document.removeEventListener('mediaQueryUpdated',_mediaQueryUpdated);
 
     window.removeEventListener('hashchange', _hideSidebar);
+    window.removeEventListener('keyup', _escape);
 
     // Remove properties of this behavior
     A17.Helpers.purgeProperties(this);

--- a/frontend/scss/organisms/_o-article__primary-actions.scss
+++ b/frontend/scss/organisms/_o-article__primary-actions.scss
@@ -282,6 +282,11 @@
       align-items: normal;
     }
 
+    .p-digitalpublicationarticle-show.p-t-contributions &,
+    .p-digitalpublicationarticle-show.p-t-entry & {
+      background-color: unset;
+    }
+
     .p-digitalpublicationarticle-show.p-t-contributions:not(.is-sidebar-overlay) &,
     .p-digitalpublicationarticle-show.p-t-entry:not(.is-sidebar-overlay) & {
       margin-bottom: 40px;

--- a/frontend/scss/organisms/_o-article__primary-actions.scss
+++ b/frontend/scss/organisms/_o-article__primary-actions.scss
@@ -277,12 +277,13 @@
     display: flex;
     align-items: center;
 
-    .is-sidebar-fixed & {
+    .is-sidebar-fixed:not(.is-sidebar-overlay) & {
       display: block;
       align-items: normal;
     }
 
-    .p-digitalpublicationarticle-show.p-t-contributions & {
+    .p-digitalpublicationarticle-show.p-t-contributions:not(.is-sidebar-overlay) &,
+    .p-digitalpublicationarticle-show.p-t-entry:not(.is-sidebar-overlay) & {
       margin-bottom: 40px;
     }
 

--- a/frontend/scss/organisms/_o-article__primary-actions.scss
+++ b/frontend/scss/organisms/_o-article__primary-actions.scss
@@ -258,6 +258,7 @@
 // Styles specific to digital publications and their sections:
 .o-article__primary-actions--digital-publication {
   @extend %o-article__primary-actions--toggleable;
+  margin-top: 40px;
   padding-top: 0px;
   z-index: 4;
 
@@ -316,6 +317,10 @@
 
     a:active {
       color: $color__link--publications-active;
+    }
+
+    @include breakpoint('medium-') {
+      margin-top: 40px;
     }
 
     @include breakpoint('large+') {

--- a/frontend/scss/organisms/_o-article__primary-actions.scss
+++ b/frontend/scss/organisms/_o-article__primary-actions.scss
@@ -332,6 +332,8 @@
 
     @include breakpoint('medium-') {
       margin-top: 40px;
+      padding-right: 20px;
+      width: 100%;
     }
 
     @include breakpoint('large+') {

--- a/frontend/scss/organisms/_o-article__primary-actions.scss
+++ b/frontend/scss/organisms/_o-article__primary-actions.scss
@@ -266,7 +266,8 @@
     margin-top: 40px;
   }
 
-  .o-sticky-sidebar__sticker {
+  .is-sidebar-overlay & .o-sticky-sidebar__sticker {
+    overflow-y: unset;
     padding-bottom: 60px;
   }
 

--- a/frontend/scss/organisms/_o-article__primary-actions.scss
+++ b/frontend/scss/organisms/_o-article__primary-actions.scss
@@ -258,9 +258,13 @@
 // Styles specific to digital publications and their sections:
 .o-article__primary-actions--digital-publication {
   @extend %o-article__primary-actions--toggleable;
-  margin-top: 40px;
   padding-top: 0px;
   z-index: 4;
+
+  .p-digitalpublications-show &,
+  .p-digitalpublications-showlisting & {
+    margin-top: 40px;
+  }
 
   .o-sticky-sidebar__sticker {
     padding-bottom: 60px;

--- a/frontend/scss/pages/_p-issuearticle-show.scss
+++ b/frontend/scss/pages/_p-issuearticle-show.scss
@@ -519,7 +519,8 @@ Styling related specifically to digital publications
   }
 }
 
-.p-digitalpublicationarticle-show.p-t-contributions {
+.p-digitalpublicationarticle-show.p-t-contributions,
+.p-digitalpublicationarticle-show.p-t-entry {
   .m-article-actions--publication__logo {
     height: 150px;
     margin-bottom: 0;

--- a/frontend/scss/pages/_p-issuearticle-show.scss
+++ b/frontend/scss/pages/_p-issuearticle-show.scss
@@ -233,10 +233,6 @@
     @include breakpoint('xlarge') {
       width: colspan(18, 'xlarge');
     }
-
-    .o-sticky-sidebar__sticker {
-      padding-right: 0;
-    }
   }
 
   .o-article__secondary-actions {

--- a/frontend/scss/pages/_p-issuearticle-show.scss
+++ b/frontend/scss/pages/_p-issuearticle-show.scss
@@ -516,7 +516,7 @@ Styling related specifically to digital publications
 }
 
 .p-digitalpublicationarticle-show.p-t-contributions,
-.p-digitalpublicationarticle-show.p-t-entry {
+.p-digitalpublicationarticle-show.p-t-entry.is-sidebar-overlay {
   .m-article-actions--publication__logo {
     height: 150px;
     margin-bottom: 0;

--- a/frontend/scss/pages/_p-issuearticle-show.scss
+++ b/frontend/scss/pages/_p-issuearticle-show.scss
@@ -114,6 +114,7 @@
       width: 100%;
       display: flex;
       align-items: center;
+      padding-right: 20px;
     }
 
     &::before {

--- a/frontend/scss/state/_s-sticky-sidebar.scss
+++ b/frontend/scss/state/_s-sticky-sidebar.scss
@@ -86,6 +86,16 @@ For _p-issuearticle-show.scss and _p-issue-show.scss
         width: 100vw;
       }
     }
+    @include breakpoint('small') {
+      .o-sticky-sidebar__sticker {
+        width: calc(colspan(19, 'small') + map-get($outer-gutters, 'small'));
+      }
+    }
+    @include breakpoint('medium') {
+      .o-sticky-sidebar__sticker {
+        width: calc(colspan(19, 'medium') + map-get($outer-gutters, 'medium'));
+      }
+    }
   }
 
   @include breakpoint('large+') {


### PR DESCRIPTION
This makes the width of the table of contents in medium and small screen sizes the same proportional width as in large and xlarge sizes. (I've left the width of the xsmall TOC as full width, as that seems sensible.) It also adds a margin to the top of the TOC.