### PR TITLE
Make digipub header sizes consistent

### DIFF
--- a/frontend/scss/molecules/_m-article-header.scss
+++ b/frontend/scss/molecules/_m-article-header.scss
@@ -1126,6 +1126,16 @@
         z-index: map-get($zindexs, 'header');
       }
     }
+
+    .title {
+      font-size: 22px;
+      line-height: 28px;
+      margin-bottom: 26px;
+    }
+
+    .subtitle {
+      display: none;
+    }
   }
 
   @include breakpoint('medium+') {
@@ -1138,6 +1148,8 @@
     }
 
     .title {
+      font-size: 28px;
+      line-height: 32px;
       margin-top: 35px;
     }
 

--- a/frontend/scss/pages/_p-issuearticle-show.scss
+++ b/frontend/scss/pages/_p-issuearticle-show.scss
@@ -143,7 +143,11 @@
         font-family-loaded: $serif-font--loaded,
         font-loaded-class: $serif-font-loaded-class,
         settings: (
-          'xsmall': (font-size: 22, line-height: 23, push: 0),
+          'xlarge': (font-size: 20, line-height: 24, push: 0),
+          'large': (font-size: 20, line-height: 24, push: 0),
+          'medium': (font-size: 28, line-height: 32, push: 0),
+          'small': (font-size: 22, line-height: 38, push: 0),
+          'xsmall': (font-size: 22, line-height: 38, push: 0),
         )
       )
     ));
@@ -222,6 +226,28 @@
       }
       @include breakpoint('xlarge') {
         width: colspan(25, 'xlarge');
+      }
+    }
+  }
+
+  .o-article>.m-article-header__text {
+    .f-headline-editorial {
+      @include breakpoint('large+') {
+        font-size: 28px;
+        line-height: 32px;
+      }
+    }
+  }
+
+  .o-article__body>.m-article-header__text {
+    .f-headline-editorial {
+      @include breakpoint('small-') {
+        font-size: 22px;
+        line-height: 28px;
+      }
+      @include breakpoint('medium') {
+        font-size: 28px;
+        line-height: 32px;
       }
     }
   }

--- a/resources/views/site/digitalPublicationArticleDetail.blade.php
+++ b/resources/views/site/digitalPublicationArticleDetail.blade.php
@@ -53,7 +53,8 @@
         {{-- Intentionally left blank for layout --}}
     </div>
 
-    @if ($item->article_type !== DigitalPublicationArticleType::Entry)
+    @if ($item->article_type !== DigitalPublicationArticleType::About
+        && $item->article_type !== DigitalPublicationArticleType::Entry)
         <div class="m-article-header__text u-show@large+">
             @component('components.atoms._title')
                 @slot('tag', 'h1')


### PR DESCRIPTION
This change makes headers for digipub pages consistent across screen sizes and aligned with the headers in the mockups. Also, it removes the header for About pages `large+` screen sizes.