### PR TITLE
Refactor and redesign magazine issue archive

### DIFF
--- a/app/Http/Controllers/MagazineIssueController.php
+++ b/app/Http/Controllers/MagazineIssueController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers;
 
 use App\Repositories\MagazineIssueRepository;
+use Illuminate\Support\Carbon;
 
 class MagazineIssueController extends FrontController
 {
@@ -24,13 +25,7 @@ class MagazineIssueController extends FrontController
 
     public function show($id, $slug = null, $isRequestForLatest = false)
     {
-        $issues = $this->repository->published()->ordered()->get();
-        $item = $issues->where('id', (int) $id)->first();
-
-        if (!$item) {
-            abort(404);
-        }
-
+        $item = $this->repository->findOrFail($id);
         $canonicalPath = route('magazine-issues.show', ['id' => $item->id, 'slug' => $item->getSlug()]);
 
         if (!$isRequestForLatest) {
@@ -43,11 +38,28 @@ class MagazineIssueController extends FrontController
         $this->seo->setDescription($item->meta_description ?: $item->list_description); // Issues have no blocks
         $this->seo->setImage($item->imageFront('hero'));
 
+        $issuesByYear = $this->repository
+            ->published()
+            ->ordered()
+            ->get()
+            ->mapToGroups(function ($issue) {
+                $year = (new Carbon($issue->publish_start_date))->year;
+                return [$year => $issue];
+            });
+        $issueArchive = ['title' => 'Archive', 'items' => []];
+        foreach ($issuesByYear as $year => $yearIssues) {
+            $byYear = ['title' => (string)$year];
+            foreach ($yearIssues as $issue) {
+                $byYear['items'][] = ['title' => $issue->title, 'url' => route('magazine-issues.show', [$issue])];
+            }
+            $issueArchive['items'][] = $byYear;
+        }
+
         return view('site.magazineIssueDetail', [
             'item' => $item,
             'contrastHeader' => false,
             'borderlessHeader' => false,
-            'issues' => $issues,
+            'issues' => [$issueArchive],
             'welcomeNote' => $this->repository->getWelcomeNote($item),
             'canonicalUrl' => $canonicalPath,
         ]);

--- a/frontend/js/behaviors/core/stickySidebar.js
+++ b/frontend/js/behaviors/core/stickySidebar.js
@@ -68,7 +68,7 @@ const stickySidebar = function(container){
     navContainer = document.querySelector('.g-header');
     stickyHeaderContainer = document.querySelector('.m-article-header');
 
-    // `containerToo` is caluclated in the `handleResize` method
+    // `containerTop` is caluclated in the `handleResize` method
     if (scrollTop < containerTop - (document.documentElement.classList.contains('s-sticky-digital-publication-header') ? stickyHeaderContainer.clientHeight : 0)) {
       top();
       container.style.marginTop = '0px';
@@ -77,13 +77,6 @@ const stickySidebar = function(container){
         bottom();
       } else {
         sticky();
-
-        // Only add margin if the screen width is 1200px or above
-        if (window.innerWidth >= 1200) {
-          container.style.marginTop = (document.documentElement.classList.contains('p-digitalpublicationarticle-show') ? 0 : (!document.documentElement.classList.contains('s-unsticky-header') ? navContainer.clientHeight : 0) + (!document.documentElement.classList.contains('s-unsticky-digital-publication-header') ? stickyHeaderContainer.clientHeight : 0)) + 'px';
-        } else {
-          container.style.marginTop = '0px';
-        }
       }
     }
   }

--- a/frontend/scss/organisms/_o-accordion.scss
+++ b/frontend/scss/organisms/_o-accordion.scss
@@ -3,7 +3,7 @@
   h3 {
     padding: 25px 0;
   }
-  
+
   .o-article + & {
     margin-top: 40px;
   }
@@ -390,7 +390,8 @@
   margin-bottom: 48px;
 }
 
-.o-accordion.o-accordion--publication-sidebar {
+.o-accordion.o-accordion--publication-sidebar,
+.o-accordion.o-accordion--magazine-issue-archive {
 
   h3 {
     padding: 1px 0 0 0;
@@ -414,7 +415,8 @@
     }
   }
 
-  .o-accordion__panel > .o-accordion--publication-sidebar {
+  .o-accordion__panel > .o-accordion--publication-sidebar,
+  .o-accordion__panel > .o-accordion.o-accordion--magazine-issue-archive {
     padding-left: 20px;
     &:last-of-type {
       padding-bottom: 20px;

--- a/frontend/scss/organisms/_o-article__primary-actions.scss
+++ b/frontend/scss/organisms/_o-article__primary-actions.scss
@@ -388,6 +388,25 @@
 }
 
 // Styles specific to magazine issues:
+.p-magazineissue-latest,
+.p-magazineissue-show {
+  @include breakpoint('medium-') {
+    .o-article {
+      display: flex;
+      flex-direction: column;
+
+      &>.m-article-header {
+        order: 1;
+      }
+      &>.o-article__primary-actions {
+        order: 3;
+      }
+      &>.o-article__body {
+        order: 2;
+      }
+    }
+  }
+}
 .o-article__primary-actions--magazine-issue {
   .o-sticky-sidebar__sticker {
     padding-top: 100px;

--- a/frontend/scss/organisms/_o-article__primary-actions.scss
+++ b/frontend/scss/organisms/_o-article__primary-actions.scss
@@ -401,9 +401,20 @@
     }
   }
 
-  #h-nav-magazine-social {
+  button#archive {
+    color: $color__magazine__byzantium !important;
+
+    .o-accordion__trigger-icon {
+      color: $color__black__90;
+    }
+  }
+
+  #h-nav-magazine-social,
+  hr+.o-accordion .o-accordion>.o-accordion__title>.o-accordion__trigger {
+    color: $color__black--90 !important;
+    font-family: $sans-serif-font--loaded;
+    font-size: 17px;
     font-weight: 400;
-    color: $color__black--90;
   }
 }
 

--- a/frontend/scss/setup/_colors.scss
+++ b/frontend/scss/setup/_colors.scss
@@ -1,4 +1,5 @@
 @import '../themes/rlc';
+@import '../themes/magazine';
 
 // Main Color List - try not to use
 // Reds

--- a/frontend/scss/state/_s-sticky-sidebar.scss
+++ b/frontend/scss/state/_s-sticky-sidebar.scss
@@ -13,7 +13,7 @@ For _p-issuearticle-show.scss and _p-issue-show.scss
   }
 
   .o-sticky-sidebar__sticker {
-    height: 100vh;
+    max-height: 100vh;
   }
 
   &.is-sidebar-overlay {

--- a/frontend/scss/themes/_magazine.scss
+++ b/frontend/scss/themes/_magazine.scss
@@ -1,0 +1,4 @@
+// Magazine Issue color list
+// Color names are taken from https://www.color-name.com/.
+
+$color__magazine__byzantium: #6F2562;

--- a/resources/views/components/molecules/_m-article-actions----magazine-issue.blade.php
+++ b/resources/views/components/molecules/_m-article-actions----magazine-issue.blade.php
@@ -26,35 +26,14 @@
         </ul>
     </div>
 
-    @if (isset($issues) && $issues->count() > 1)
+    @if (isset($issues))
         <hr>
-
-        <ul class="m-article-actions--journal__issues" data-behavior="dragScroll">
-            @foreach($issues as $issue)
-                <li>
-                    @component('components.atoms._tag')
-                        @slot('href', route('magazine-issues.show', [
-                            'id' => $issue->id,
-                            'slug' => $issue->getSlug(),
-                        ]))
-                        @slot('variation', 'tag--magazine tag--senary tag--w-image')
-                        @slot('gtmAttributes', 'data-gtm-event="' . StringHelpers::getUtf8Slug( $issue->title ) . '" data-gtm-event-category="magazine-sidebar-issue"')
-                        @if (!empty($issue->imageFront('hero', 'default')))
-                            @component('components.atoms._img')
-                                @slot('image', $issue->imageFront('hero', 'default'))
-                                @slot('settings', array(
-                                    'fit' => 'crop',
-                                    'ratio' => '1:1',
-                                    'srcset' => array(30,60),
-                                    'sizes' => '60px',
-                                ))
-                            @endcomponent
-                        @endif
-                        {!! $issue->present()->title !!}
-                    @endcomponent
-                </li>
-            @endforeach
-        </ul>
+        @component('components.organisms._o-accordion-tree')
+            @slot('variation', 'o-accordion--magazine-issue-archive')
+            @slot('titleFont', 'f-tag-2')
+            @slot('items', $issues)
+            @slot('active', true)
+        @endcomponent
     @endif
 
     <hr class="u-hide@large u-hide@xlarge">

--- a/resources/views/components/molecules/_m-article-actions----magazine-issue.blade.php
+++ b/resources/views/components/molecules/_m-article-actions----magazine-issue.blade.php
@@ -36,8 +36,6 @@
         @endcomponent
     @endif
 
-    <hr class="u-hide@large u-hide@xlarge">
-
 </div>
 
 <div class="o-sticky-sidebar__placeholder"></div>

--- a/resources/views/components/organisms/_o-accordion-tree.blade.php
+++ b/resources/views/components/organisms/_o-accordion-tree.blade.php
@@ -1,0 +1,42 @@
+<div class="o-accordion{{ (isset($variation)) ? ' '.$variation : '' }}" data-behavior="accordion">
+    @foreach ($items as $item)
+        @if (isset($item['items']) && count($item['items']) > 0)
+            <h3 class="o-accordion__title">
+                <button
+                    id="{{ StringHelpers::getUtf8Slug($item['title']) }}"
+                    class="o-accordion__trigger {{ $titleFont ?? 'f-list-3' }}"
+                    tabindex="0"{!! (isset($gtmAttributes)) ? ' '.$gtmAttributes.'' : '' !!}
+                    aria-expanded="{{ (isset($active) and $active) ? 'true' : 'false' }}"
+                >
+                    {!! $item['title'] !!}
+                    <span class="o-accordion__trigger-icon">
+                        <svg class="icon--plus"><use xlink:href="#icon--plus" /></svg>
+                        <svg class="icon--minus"><use xlink:href="#icon--minus" /></svg>
+                    </span>
+                </button>
+            </h3>
+            <div
+                id="panel_{{ StringHelpers::getUtf8Slug($item['title']) }}"
+                class="o-accordion__panel"
+                aria-labelledby="{{ StringHelpers::getUtf8Slug($item['title']) }}"
+                aria-hidden="{{ (isset($active) and $active) ? 'false' : 'true' }}"
+            >
+                @component('components.organisms._o-accordion-tree')
+                    @slot('variation', $variation)
+                    @slot('titleFont', $titleFont)
+                    @slot('title', $item['title'])
+                    @slot('items', $item['items'])
+                @endcomponent
+            </div>
+        @else
+            <span class="m-link-list__item o-accordion__panel-content">
+                <a
+                    class="m-link-list__trigger f-secondary"
+                    href="{{ $item['url'] }}"{!! (isset($item['gtmAttributes'])) ? ' '.$item['gtmAttributes'].'' : '' !!}
+                >
+                    <span class="m-link-list__label">{!! $item['title'] !!}</span>
+                </a>
+            </span>
+        @endif
+    @endforeach
+</div>

--- a/resources/views/components/organisms/_o-accordion-tree.blade.php
+++ b/resources/views/components/organisms/_o-accordion-tree.blade.php
@@ -1,3 +1,26 @@
+{{--
+    Expects $items to be in the format:
+    [
+        [
+            'title' => 'Level 1 title',
+            'items' => [
+                [
+                    'title' => 'Level 2 title',
+                    'items' => [
+                        [
+                            'title' => 'Level 3 item',
+                            'url' => 'https://some.link',
+                        ],
+                        [
+                            'title' => 'Another level 3 item',
+                            'url' => 'https://some-other.link',
+                        ]
+                    ]
+                ],
+            ],
+        ]
+    ]
+--}}
 <div class="o-accordion{{ (isset($variation)) ? ' '.$variation : '' }}" data-behavior="accordion">
     @foreach ($items as $item)
         @if (isset($item['items']) && count($item['items']) > 0)


### PR DESCRIPTION
This change adapts Trevin's work on the digipub table of contents template to be reused for more generic data. Then it uses that new template to refactor the issue archive on the magazine pages' sidebar.