### PR TITLE
Fix TOC hidden on scroll

### DIFF
--- a/frontend/js/behaviors/core/stickySidebar.js
+++ b/frontend/js/behaviors/core/stickySidebar.js
@@ -2,7 +2,8 @@ import { triggerCustomEvent, setFocusOnTarget } from '@area17/a17-helpers';
 import { mediaQuery } from '../../functions/core';
 
 const stickySidebar = function(container){
-  const isDigitalPublicationArticle = document.documentElement.classList.contains('p-digitalpublicationarticle-show');
+  const isDigitalPublicationLanding = document.documentElement.classList.contains('p-digitalpublications-show');
+  const isDigitalPublicationListing = document.documentElement.classList.contains('p-digitalpublications-showlisting');
 
   const getOffsetTop = element => {
     let offsetTop = 0;
@@ -87,7 +88,7 @@ const stickySidebar = function(container){
         let marginToAdd = 0;
         // Only add margin if the screen width is 1200px or above
         if (window.innerWidth >= 1200) {
-          if (!isDigitalPublicationArticle) {
+          if (isDigitalPublicationLanding || isDigitalPublicationListing) {
             marginToAdd += !hasUnstickyHeader ? navContainer.clientHeight : 0;
             marginToAdd += !hasDigitalPublicationUnstickyHeader ? stickyHeaderContainer.clientHeight : 0;
           }

--- a/frontend/js/behaviors/core/stickySidebar.js
+++ b/frontend/js/behaviors/core/stickySidebar.js
@@ -27,6 +27,11 @@ const stickySidebar = function(container){
     return offsetTop;
   }
 
+  function _getPaddingTop(node) {
+    let style = window.getComputedStyle(node);
+    return parseInt(style.getPropertyValue('padding-top'));
+}
+
   const setState = targetState => {
     let classList = document.documentElement.classList;
 
@@ -56,6 +61,7 @@ const stickySidebar = function(container){
   function update() {
     const article = document.querySelector('.o-article');
     const hasUnstickyHeader = document.documentElement.classList.contains('s-unsticky-header');
+    const hasStickyNav = document.documentElement.classList.contains('s-scroll-direction-up');
     const hasDigitalPublicationStickyHeader = document.documentElement.classList.contains('s-sticky-digital-publication-header');
     const hasDigitalPublicationUnstickyHeader = document.documentElement.classList.contains('s-unsticky-digital-publication-header');
     const navContainer = document.querySelector('.g-header');
@@ -73,9 +79,15 @@ const stickySidebar = function(container){
     } else {
       sticky();
       // Only add margin if the screen width is 1200px or above
-      if (window.innerWidth >= 1200 && (isDigitalPublicationLanding || isDigitalPublicationListing)) {
-        marginToAdd += !hasUnstickyHeader ? navContainer.clientHeight : 0;
-        marginToAdd += !hasDigitalPublicationUnstickyHeader ? stickyHeaderContainer.clientHeight : 0;
+      if (window.innerWidth >= 1200) {
+        if (isDigitalPublicationLanding || isDigitalPublicationListing) {
+          marginToAdd += !hasUnstickyHeader ? navContainer.clientHeight : 0;
+          marginToAdd += !hasDigitalPublicationUnstickyHeader ? stickyHeaderContainer.clientHeight : 0;
+        }
+        if (isMagazineIssue) {
+          let paddingTop = _getPaddingTop(container);
+          marginToAdd += hasStickyNav ? navContainer.clientHeight - paddingTop : 0;
+        }
       }
     }
     container.style.marginTop = marginToAdd + 'px';

--- a/frontend/js/behaviors/core/stickySidebar.js
+++ b/frontend/js/behaviors/core/stickySidebar.js
@@ -102,6 +102,8 @@ const stickySidebar = function(container){
     top();
     let contributionHeaderHeight = 0;
     let logoList = document.querySelectorAll(logoSelector);
+    let hasDigitalPublicationStickyHeader = document.documentElement.classList.contains('s-sticky-digital-publication-header');
+
     for (let i = 0; i < logoList.length; i++) {
       contributionHeaderHeight += logoList[i].clientHeight;
     }

--- a/frontend/js/behaviors/core/stickySidebar.js
+++ b/frontend/js/behaviors/core/stickySidebar.js
@@ -77,15 +77,14 @@ const stickySidebar = function(container){
     // `containerTop` is caluclated in the `handleResize` method
     let digitalPublicaitonStickyHeaderHeight = hasDigitalPublicationStickyHeader ? stickyHeaderContainer.clientHeight : 0;
     let unstickyNavHeight = hasUnstickyHeader ? navContainer.clientHeight : 0;
+    let marginToAdd = 0;
     if (scrollTop < containerTop - digitalPublicaitonStickyHeaderHeight) {
       top();
-      container.style.marginTop = '0px';
     } else {
       if (scrollTop + containerHeight > article.offsetHeight + unstickyNavHeight) {
         bottom();
       } else {
         sticky();
-        let marginToAdd = 0;
         // Only add margin if the screen width is 1200px or above
         if (window.innerWidth >= 1200) {
           if (isDigitalPublicationLanding || isDigitalPublicationListing) {
@@ -93,9 +92,9 @@ const stickySidebar = function(container){
             marginToAdd += !hasDigitalPublicationUnstickyHeader ? stickyHeaderContainer.clientHeight : 0;
           }
         }
-        container.style.marginTop = marginToAdd + 'px';
       }
     }
+    container.style.marginTop = marginToAdd + 'px';
   }
 
   function top() {

--- a/frontend/js/behaviors/core/stickySidebar.js
+++ b/frontend/js/behaviors/core/stickySidebar.js
@@ -66,18 +66,14 @@ const stickySidebar = function(container){
     // `containerTop` is caluclated in the `handleResize` method
     if (scrollTop < containerTop - digitalPublicaitonStickyHeaderHeight) {
       top();
+    } else if (scrollTop + container.offsetHeight > article.offsetHeight + unstickyNavHeight) {
+      bottom();
     } else {
-      if (scrollTop + container.offsetHeight > article.offsetHeight + unstickyNavHeight) {
-        bottom();
-      } else {
-        sticky();
-        // Only add margin if the screen width is 1200px or above
-        if (window.innerWidth >= 1200) {
-          if (isDigitalPublicationLanding || isDigitalPublicationListing) {
-            marginToAdd += !hasUnstickyHeader ? navContainer.clientHeight : 0;
-            marginToAdd += !hasDigitalPublicationUnstickyHeader ? stickyHeaderContainer.clientHeight : 0;
-          }
-        }
+      sticky();
+      // Only add margin if the screen width is 1200px or above
+      if (window.innerWidth >= 1200 && (isDigitalPublicationLanding || isDigitalPublicationListing)) {
+        marginToAdd += !hasUnstickyHeader ? navContainer.clientHeight : 0;
+        marginToAdd += !hasDigitalPublicationUnstickyHeader ? stickyHeaderContainer.clientHeight : 0;
       }
     }
     container.style.marginTop = marginToAdd + 'px';

--- a/frontend/js/behaviors/core/stickySidebar.js
+++ b/frontend/js/behaviors/core/stickySidebar.js
@@ -2,11 +2,11 @@ import { triggerCustomEvent, setFocusOnTarget } from '@area17/a17-helpers';
 import { mediaQuery } from '../../functions/core';
 
 const stickySidebar = function(container){
-  const hasDigitalPublicationStickyHeader = document.documentElement.classList.contains('s-sticky-digital-publication-header');
-  const hasDigitalPublicationUnstickyHeader = document.documentElement.classList.contains('s-unsticky-digital-publication-header');
   const isDigitalPublicationArticle = document.documentElement.classList.contains('p-digitalpublicationarticle-show');
   const isDigitalPublicationLanding = document.documentElement.classList.contains('p-digitalpublications-show');
   const isDigitalPublicationListing = document.documentElement.classList.contains('p-digitalpublications-showlisting');
+  const isContribution = document.documentElement.classList.contains('p-t-contributions');
+  const isMagazineIssue = document.documentElement.classList.contains('p-magazineissue-latest') || document.documentElement.classList.contains('p-magazineissue-show');
   const logoSelector = '.m-article-actions--publication__logo';
   const logo = document.querySelector(logoSelector);
   const sidebarOverlayState = 'is-sidebar-overlay';
@@ -56,6 +56,8 @@ const stickySidebar = function(container){
   function update() {
     const article = document.querySelector('.o-article');
     const hasUnstickyHeader = document.documentElement.classList.contains('s-unsticky-header');
+    const hasDigitalPublicationStickyHeader = document.documentElement.classList.contains('s-sticky-digital-publication-header');
+    const hasDigitalPublicationUnstickyHeader = document.documentElement.classList.contains('s-unsticky-digital-publication-header');
     const navContainer = document.querySelector('.g-header');
     const scrollTop = document.documentElement.scrollTop || document.body.scrollTop;
 
@@ -108,9 +110,11 @@ const stickySidebar = function(container){
     if (hasDigitalPublicationStickyHeader) {
       containerTop -= stickyHeaderContainer.offsetHeight;
     }
-    let isContribution = document.documentElement.classList.contains('p-t-contributions');
-    if (isDigitalPublicationArticle && isContribution) {
+    if ((isDigitalPublicationArticle && isContribution) || isDigitalPublicationLanding) {
       containerTop += contributionHeaderHeight;
+    }
+    if (isMagazineIssue) {
+      containerTop -= 30;
     }
 
     logo.setAttribute('style', 'display: block');

--- a/frontend/js/behaviors/core/stickySidebar.js
+++ b/frontend/js/behaviors/core/stickySidebar.js
@@ -2,22 +2,21 @@ import { triggerCustomEvent, setFocusOnTarget } from '@area17/a17-helpers';
 import { mediaQuery } from '../../functions/core';
 
 const stickySidebar = function(container){
+  const hasDigitalPublicationStickyHeader = document.documentElement.classList.contains('s-sticky-digital-publication-header');
+  const hasDigitalPublicationUnstickyHeader = document.documentElement.classList.contains('s-unsticky-digital-publication-header');
+  const isDigitalPublicationArticle = document.documentElement.classList.contains('p-digitalpublicationarticle-show');
   const isDigitalPublicationLanding = document.documentElement.classList.contains('p-digitalpublications-show');
   const isDigitalPublicationListing = document.documentElement.classList.contains('p-digitalpublications-showlisting');
-  const logo = document.querySelector('.m-article-actions--publication__logo');
+  const logoSelector = '.m-article-actions--publication__logo';
+  const logo = document.querySelector(logoSelector);
   const sidebarOverlayState = 'is-sidebar-overlay';
+  const stickyHeaderContainer = document.querySelector('.m-article-header');
 
-  let article;
-  let scrollTop;
   let containerTop;
-  let containerHeight;
-  let navContainer;
-  let stickyHeaderContainer;
-  let contributionHeaderHeight;
+  let currentState;
   let overlayActive = document.documentElement.classList.contains(sidebarOverlayState);
   let savedFocus;
   let savedScroll;
-  let currentState;
 
   const getOffsetTop = element => {
     let offsetTop = 0;
@@ -54,28 +53,21 @@ const stickySidebar = function(container){
     }
   }
 
-
   function update() {
-    const hasDigitalPublicationStickyHeader = document.documentElement.classList.contains('s-sticky-digital-publication-header');
-    const hasDigitalPublicationUnstickyHeader = document.documentElement.classList.contains('s-unsticky-digital-publication-header');
+    const article = document.querySelector('.o-article');
     const hasUnstickyHeader = document.documentElement.classList.contains('s-unsticky-header');
+    const navContainer = document.querySelector('.g-header');
+    const scrollTop = document.documentElement.scrollTop || document.body.scrollTop;
 
-    scrollTop = document.documentElement.scrollTop || document.body.scrollTop;
-
-    containerHeight = container.offsetHeight;
-
-    article = document.querySelector('.o-article');
-    navContainer = document.querySelector('.g-header');
-    stickyHeaderContainer = document.querySelector('.m-article-header');
-
-    // `containerTop` is caluclated in the `handleResize` method
     let digitalPublicaitonStickyHeaderHeight = hasDigitalPublicationStickyHeader ? stickyHeaderContainer.clientHeight : 0;
     let unstickyNavHeight = hasUnstickyHeader ? navContainer.clientHeight : 0;
     let marginToAdd = 0;
+
+    // `containerTop` is caluclated in the `handleResize` method
     if (scrollTop < containerTop - digitalPublicaitonStickyHeaderHeight) {
       top();
     } else {
-      if (scrollTop + containerHeight > article.offsetHeight + unstickyNavHeight) {
+      if (scrollTop + container.offsetHeight > article.offsetHeight + unstickyNavHeight) {
         bottom();
       } else {
         sticky();
@@ -110,19 +102,18 @@ const stickySidebar = function(container){
 
   function handleResize() {
     top();
-    stickyHeaderContainer = document.querySelector('.m-article-header');
-
-    contributionHeaderHeight = 0;
-    let logoList = document.querySelectorAll('.m-article-actions--publication__logo');
+    let contributionHeaderHeight = 0;
+    let logoList = document.querySelectorAll(logoSelector);
     for (let i = 0; i < logoList.length; i++) {
       contributionHeaderHeight += logoList[i].clientHeight;
     }
 
     containerTop = getOffsetTop(container) + document.body.scrollTop;
-    if (document.documentElement.classList.contains('s-sticky-digital-publication-header')) {
+    if (hasDigitalPublicationStickyHeader) {
       containerTop -= stickyHeaderContainer.offsetHeight;
     }
-    if (document.documentElement.classList.contains('p-digitalpublicationarticle-show') && document.documentElement.classList.contains('p-t-contributions')) {
+    let isContribution = document.documentElement.classList.contains('p-t-contributions');
+    if (isDigitalPublicationArticle && isContribution) {
       containerTop += contributionHeaderHeight;
     }
 

--- a/frontend/js/behaviors/core/stickySidebar.js
+++ b/frontend/js/behaviors/core/stickySidebar.js
@@ -9,7 +9,6 @@ const stickySidebar = function(container){
 
   let article;
   let scrollTop;
-  let windowHeight;
   let containerTop;
   let containerHeight;
   let navContainer;
@@ -111,7 +110,6 @@ const stickySidebar = function(container){
 
   function handleResize() {
     top();
-    windowHeight = window.innerHeight || document.documentElement.clientHeight;
     stickyHeaderContainer = document.querySelector('.m-article-header');
 
     contributionHeaderHeight = 0;

--- a/frontend/js/behaviors/core/stickySidebar.js
+++ b/frontend/js/behaviors/core/stickySidebar.js
@@ -4,6 +4,21 @@ import { mediaQuery } from '../../functions/core';
 const stickySidebar = function(container){
   const isDigitalPublicationLanding = document.documentElement.classList.contains('p-digitalpublications-show');
   const isDigitalPublicationListing = document.documentElement.classList.contains('p-digitalpublications-showlisting');
+  const logo = document.querySelector('.m-article-actions--publication__logo');
+  const sidebarOverlayState = 'is-sidebar-overlay';
+
+  let article;
+  let scrollTop;
+  let windowHeight;
+  let containerTop;
+  let containerHeight;
+  let navContainer;
+  let stickyHeaderContainer;
+  let contributionHeaderHeight;
+  let overlayActive = document.documentElement.classList.contains(sidebarOverlayState);
+  let savedFocus;
+  let savedScroll;
+  let currentState;
 
   const getOffsetTop = element => {
     let offsetTop = 0;
@@ -40,26 +55,6 @@ const stickySidebar = function(container){
     }
   }
 
-  let article;
-  let logo = document.querySelector('.m-article-actions--publication__logo');
-
-  let scrollTop;
-
-  let windowHeight;
-  let containerTop;
-  let containerHeight;
-
-  let navContainer;
-  let stickyHeaderContainer;
-  let contributionHeaderHeight;
-
-  const sidebarOverlayState = 'is-sidebar-overlay';
-  let overlayActive = document.documentElement.classList.contains(sidebarOverlayState);
-
-  let savedFocus;
-  let savedScroll;
-
-  let currentState;
 
   function update() {
     const hasDigitalPublicationStickyHeader = document.documentElement.classList.contains('s-sticky-digital-publication-header');

--- a/frontend/js/behaviors/core/stickySidebar.js
+++ b/frontend/js/behaviors/core/stickySidebar.js
@@ -77,6 +77,12 @@ const stickySidebar = function(container){
         bottom();
       } else {
         sticky();
+        // Only add margin if the screen width is 1200px or above
+        if (window.innerWidth >= 1200) {
+          container.style.marginTop = (document.documentElement.classList.contains('p-digitalpublicationarticle-show') ? 0 : (!document.documentElement.classList.contains('s-unsticky-header') ? navContainer.clientHeight : 0) + (!document.documentElement.classList.contains('s-unsticky-digital-publication-header') ? stickyHeaderContainer.clientHeight : 0)) + 'px';
+        } else {
+          container.style.marginTop = '0px';
+        }
       }
     }
   }

--- a/frontend/js/behaviors/core/stickySidebar.js
+++ b/frontend/js/behaviors/core/stickySidebar.js
@@ -2,6 +2,7 @@ import { triggerCustomEvent, setFocusOnTarget } from '@area17/a17-helpers';
 import { mediaQuery } from '../../functions/core';
 
 const stickySidebar = function(container){
+  const isDigitalPublicationArticle = document.documentElement.classList.contains('p-digitalpublicationarticle-show');
 
   const getOffsetTop = element => {
     let offsetTop = 0;
@@ -60,6 +61,10 @@ const stickySidebar = function(container){
   let currentState;
 
   function update() {
+    const hasDigitalPublicationStickyHeader = document.documentElement.classList.contains('s-sticky-digital-publication-header');
+    const hasDigitalPublicationUnstickyHeader = document.documentElement.classList.contains('s-unsticky-digital-publication-header');
+    const hasUnstickyHeader = document.documentElement.classList.contains('s-unsticky-header');
+
     scrollTop = document.documentElement.scrollTop || document.body.scrollTop;
 
     containerHeight = container.offsetHeight;
@@ -69,20 +74,25 @@ const stickySidebar = function(container){
     stickyHeaderContainer = document.querySelector('.m-article-header');
 
     // `containerTop` is caluclated in the `handleResize` method
-    if (scrollTop < containerTop - (document.documentElement.classList.contains('s-sticky-digital-publication-header') ? stickyHeaderContainer.clientHeight : 0)) {
+    let digitalPublicaitonStickyHeaderHeight = hasDigitalPublicationStickyHeader ? stickyHeaderContainer.clientHeight : 0;
+    let unstickyNavHeight = hasUnstickyHeader ? navContainer.clientHeight : 0;
+    if (scrollTop < containerTop - digitalPublicaitonStickyHeaderHeight) {
       top();
       container.style.marginTop = '0px';
     } else {
-      if (scrollTop + containerHeight > article.offsetHeight + (document.documentElement.classList.contains('s-unsticky-header') ? navContainer.clientHeight : 0)) {
+      if (scrollTop + containerHeight > article.offsetHeight + unstickyNavHeight) {
         bottom();
       } else {
         sticky();
+        let marginToAdd = 0;
         // Only add margin if the screen width is 1200px or above
         if (window.innerWidth >= 1200) {
-          container.style.marginTop = (document.documentElement.classList.contains('p-digitalpublicationarticle-show') ? 0 : (!document.documentElement.classList.contains('s-unsticky-header') ? navContainer.clientHeight : 0) + (!document.documentElement.classList.contains('s-unsticky-digital-publication-header') ? stickyHeaderContainer.clientHeight : 0)) + 'px';
-        } else {
-          container.style.marginTop = '0px';
+          if (!isDigitalPublicationArticle) {
+            marginToAdd += !hasUnstickyHeader ? navContainer.clientHeight : 0;
+            marginToAdd += !hasDigitalPublicationUnstickyHeader ? stickyHeaderContainer.clientHeight : 0;
+          }
         }
+        container.style.marginTop = marginToAdd + 'px';
       }
     }
   }

--- a/frontend/scss/pages/_p-issuearticle-show.scss
+++ b/frontend/scss/pages/_p-issuearticle-show.scss
@@ -521,6 +521,10 @@
       margin-top: 8px;
     }
   }
+
+  .o-accordion__trigger {
+    background-color: transparent;
+  }
 }
 
 /***

--- a/frontend/scss/state/_s-sticky-sidebar.scss
+++ b/frontend/scss/state/_s-sticky-sidebar.scss
@@ -14,6 +14,7 @@ For _p-issuearticle-show.scss and _p-issue-show.scss
 
   .o-sticky-sidebar__sticker {
     max-height: 100vh;
+    height: 100vh;
   }
 
   &.is-sidebar-overlay {
@@ -119,7 +120,7 @@ For _p-issuearticle-show.scss and _p-issue-show.scss
             display: block;
             align-items: normal;
             height: auto;
-            margin-top: 40px;
+            margin-top: 30px;
           }
 
           @each $name in ('large', 'xlarge') {

--- a/frontend/scss/state/_s-sticky-sidebar.scss
+++ b/frontend/scss/state/_s-sticky-sidebar.scss
@@ -13,7 +13,6 @@ For _p-issuearticle-show.scss and _p-issue-show.scss
   }
 
   .o-sticky-sidebar__sticker {
-    max-height: 100vh;
     height: 100vh;
   }
 


### PR DESCRIPTION
This addresses the issue where the digipub TOC was being covered by the sticky header, while also addressing the issue where the magazine sidebar was being pushed off the page on scroll.