### PR TITLE
Special style for Magazine archive panel

### DIFF
--- a/frontend/scss/organisms/_o-accordion.scss
+++ b/frontend/scss/organisms/_o-accordion.scss
@@ -415,9 +415,19 @@
     }
   }
 
+  .o-accordion__panel > .o-accordion--publication-sidebar {
+    padding-left: 20px;
+  }
+
+  .o-accordion__panel > .o-accordion.o-accordion--magazine-issue-archive {
+    padding-left: 0;
+    &:not(:has(>.o-accordion__panel-content)) {
+      padding-left: 20px;
+    }
+  }
+
   .o-accordion__panel > .o-accordion--publication-sidebar,
   .o-accordion__panel > .o-accordion.o-accordion--magazine-issue-archive {
-    padding-left: 20px;
     &:last-of-type {
       padding-bottom: 20px;
     }


### PR DESCRIPTION
Unlike the digipub TOC, where every level is indented from its parent, the magazine archive panel should only be indented on the second "Year" level.