### PR TITLE
Fix missing CSS sourcemaps

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -68,7 +68,7 @@ module.exports = async () => {
       path: outputDir,
       publicPath: '/dist/',
     },
-    devtool: isProd ? 'source-map' : 'eval-source-map',
+    devtool: 'source-map',
     optimization: {
       minimize: isProd && !isCI,
     },


### PR DESCRIPTION
Heeding the warning from here that [MiniCssExtractPlugin](https://webpack.js.org/plugins/mini-css-extract-plugin/) isn't compatible with `eval-source-map`:

> [!WARNING]
>
> Source maps works only for source-map/nosources-source-map/hidden-nosources-source-map/hidden-source-map values because CSS only supports source maps with the sourceMappingURL comment (i.e. //# sourceMappingURL=style.css.map). If you need set devtool to another value you can enable source maps generation for extracted CSS using [sourceMap: true](https://github.com/webpack-contrib/css-loader#sourcemap) for css-loader.

Even though it seems to indicate it should be avoidable my setting `sourceMap: true`, I did find Github issues indicating this isn't actually correct, and that it needs to be 'source-map' ([#1](https://github.com/webpack-contrib/mini-css-extract-plugin/issues/29), [#2](https://github.com/webpack-contrib/mini-css-extract-plugin/issues/529))