### PR TITLE
Remove quotes from css keyword

### DIFF
--- a/frontend/scss/organisms/_o-gallery.scss
+++ b/frontend/scss/organisms/_o-gallery.scss
@@ -713,7 +713,7 @@
         @include font-styles-untuck(generate-font-obj((font-family: $serif-font,
               font-family-loaded: $serif-font--loaded,
               font-loaded-class: $serif-font-loaded-class,
-              settings: ('xsmall': (font-size: 17, line-height: 21, text-transform: 'uppercase', letter-spacing: 0.1em, push: 0),
+              settings: ('xsmall': (font-size: 17, line-height: 21, text-transform: uppercase, letter-spacing: 0.1em, push: 0),
                 'small+': (font-size: 17, line-height: 21, push: -2),
                 'medium+': (font-size: 20, line-height: 26, push: -1),
               ))));

--- a/frontend/scss/pages/types/_t-rlc.scss
+++ b/frontend/scss/pages/types/_t-rlc.scss
@@ -45,7 +45,7 @@
     font-family: var(--sans-serif);
     font-size: 21px;
     font-weight: 400;
-    text-transform: 'uppercase';
+    text-transform: uppercase;
   }
   .o-info-grid {
     @include breakpoint('small+') {
@@ -123,7 +123,7 @@
         font-family: var(--sans-serif);
         font-size: 21px;
         font-weight: 400;
-        text-transform: 'uppercase';
+        text-transform: uppercase;
       }
       &>hr {
         margin: 18px 0;


### PR DESCRIPTION
Alexis noticed that the [showcase block titles were not being uppercased anymore](https://artic-de.slack.com/archives/C02J04EGKNG/p1736442735014389). We haven't changed the styles for these RLC headers in nearly a year, so I guess in the meantime, browsers have started being strict about quoting CSS keywords. 🤷 

I looked for other quoted keywords, but these were the only ones I found.