### PR TITLE
Remove references to outdated landingpage types

### DIFF
--- a/app/Http/Controllers/LandingPagesController.php
+++ b/app/Http/Controllers/LandingPagesController.php
@@ -62,12 +62,6 @@ class LandingPagesController extends FrontController
                 $this->seo->setImage($item->imageFront('hero') ?? $item->imageFront('visit_mobile'));
                 break;
 
-            case $types->search('Research and Resources'):
-                $this->seo->setTitle($item->meta_title ?: $item->title ?: 'Research & Resources');
-                $this->seo->setDescription($item->resources_landing_intro);
-                $this->seo->setImage($item->imageFront('research_landing_image'));
-                break;
-
             case $types->search('My Museum Tour'):
                 $this->seo->setTitle($item->meta_title ?: $item->title);
                 $this->seo->setDescription($item->meta_description);
@@ -169,10 +163,6 @@ class LandingPagesController extends FrontController
                 $title = __('Visit');
                 break;
 
-            case $types->search('Research and Resources'):
-                $title = 'The Collection';
-                break;
-
             default:
                 $title = $item->title;
                 break;
@@ -248,28 +238,6 @@ class LandingPagesController extends FrontController
                     'tours_tickets_cta_module_header' => $item->labels->get('tours_tickets_cta_module_header'),
                     'tours_tickets_cta_module_button_text' => $item->labels->get('tours_tickets_cta_module_button_text'),
                     'tours_tickets_cta_module_body' => $item->labels->get('tours_tickets_cta_module_body'),
-                ];
-                break;
-
-            case $types->search('Research and Resources'):
-                $viewData = [
-                    'primaryNavCurrent' => 'collection',
-                    'intro' => $item->labels->get('resources_landing_intro'),
-                    'linksBar' => [
-                        [
-                            'href' => route('collection'),
-                            'label' => 'Artworks',
-                        ],
-                        [
-                            'href' => route('articles_publications'),
-                            'label' => 'Publications',
-                        ],
-                        [
-                            'href' => route('collection.research_resources'),
-                            'label' => 'Research',
-                            'active' => true,
-                        ],
-                    ]
                 ];
                 break;
 


### PR DESCRIPTION
Since some of the [landing page type ids were deprecated](https://github.com/art-institute-of-chicago/artic.edu/blob/develop/app/Models/LandingPage.php#L45-L49), we need to remove references to them.