### PR TITLE
Refactor to use abstracted code in Foundation

### DIFF
--- a/app/Http/Controllers/Twill/BaseApiController.php
+++ b/app/Http/Controllers/Twill/BaseApiController.php
@@ -82,7 +82,7 @@ class BaseApiController extends ModuleController
 
     public function feature()
     {
-        if (($id = $this->request->get('id'))) {
+        if ($id = $this->request->get('id')) {
             if ($apiModel = $this->getApiRepository()->getById($id)) {
                 $augmentedModel = $this->getRepository()->firstOrCreate(['datahub_id' => $apiModel->id]);
                 $this->request->merge(['id' => $augmentedModel->id]);

--- a/app/Http/Controllers/Twill/BaseApiController.php
+++ b/app/Http/Controllers/Twill/BaseApiController.php
@@ -339,13 +339,11 @@ class BaseApiController extends ModuleController
     }
 
     /**
-     * Disable default Twill orders, and do an API search first.
-     * See \Apppp\Repositories\Api\BaseApiRepository::filter().
+     * Disable default Twill order by `created_at`.
      */
     protected function orderScope(): array
     {
         $orderScope = parent::orderScope();
-        $orderScope['search'] ??= 'search';
         unset($orderScope['created_at']);
 
         return $orderScope;


### PR DESCRIPTION
This updates the website to use v3.0 of the `data-hub-foundation` package and the Twill updates that entails. I left a lot of the original code in place, so we will probably need to come back some time in the future and prune dead code.