### PR TITLE
Create index tables using the Twill table builder

### DIFF
--- a/app/Http/Controllers/Twill/ArtistController.php
+++ b/app/Http/Controllers/Twill/ArtistController.php
@@ -2,46 +2,14 @@
 
 namespace App\Http\Controllers\Twill;
 
-class ArtistController extends \App\Http\Controllers\Twill\BaseApiController
+class ArtistController extends BaseApiController
 {
-    protected $moduleName = 'artists';
-    protected $hasAugmentedModel = true;
-
-    protected $indexOptions = [
-        'publish' => false,
-        'bulkPublish' => false,
-        'feature' => false,
-        'bulkFeature' => false,
-        'restore' => false,
-        'bulkRestore' => false,
-        'bulkDelete' => false,
-        'reorder' => false,
-        'permalink' => true,
-    ];
-
-    protected $titleColumnKey = 'title';
-
-    protected $indexColumns = [
-        'title' => [
-            'title' => 'Name',
-            'field' => 'title',
-        ],
-        'augmented' => [
-            'title' => 'Augmented?',
-            'field' => 'augmented',
-            'present' => true,
-        ],
-        'datahub_id' => [
-            'title' => 'Datahub ID',
-            'field' => 'id',
-        ],
-    ];
-
-    protected $formWith = [];
-
-    protected function indexData($request)
+    public function setUpController(): void
     {
-        return [];
+        parent::setUpController();
+        $this->enableAugmentedModel();
+        $this->setModuleName('artists');
+        $this->setTitleColumnLabel('Name');
     }
 
     protected function formData($request)

--- a/app/Http/Controllers/Twill/ArtworkController.php
+++ b/app/Http/Controllers/Twill/ArtworkController.php
@@ -2,69 +2,37 @@
 
 namespace App\Http\Controllers\Twill;
 
-class ArtworkController extends \App\Http\Controllers\Twill\BaseApiController
+use A17\Twill\Services\Listings\Columns\Text;
+use A17\Twill\Services\Listings\TableColumns;
+use Illuminate\Http\JsonResponse;
+
+class ArtworkController extends BaseApiController
 {
-    protected $moduleName = 'artworks';
-    protected $hasAugmentedModel = true;
-
-    protected $indexOptions = [
-        'publish' => false,
-        'bulkPublish' => false,
-        'feature' => false,
-        'bulkFeature' => false,
-        'restore' => false,
-        'bulkRestore' => false,
-        'bulkDelete' => false,
-        'reorder' => false,
-        'permalink' => true,
-    ];
-
-    protected $indexColumns = [
-        'image' => [
-            'thumb' => true,
-            'present' => true,
-            'presenter' => 'imageThumb',
-            'variant' => [
-                'role' => 'hero',
-                'crop' => 'default',
-            ],
-        ],
-        'fullTitle' => [
-            'title' => 'Title',
-            'field' => 'fullTitle',
-        ],
-        'main_reference_number' => [
-            'title' => 'Reference number',
-            'field' => 'main_reference_number',
-        ],
-        'augmented' => [
-            'title' => 'Augmented?',
-            'field' => 'augmented',
-            'present' => true,
-        ],
-        'artist_display' => [
-            'title' => 'Artist',
-            'field' => 'artist_display',
-        ],
-    ];
-
-    protected $titleColumnKey = 'fullTitle';
-
-    protected $browserColumns = [
-        'fullTitle' => [
-            'title' => 'Title',
-            'field' => 'fullTitle',
-        ],
-    ];
-
-    /**
-     * Relations to eager load for the form view
-     */
-    protected $formWith = [];
-
-    protected function indexData($request)
+    public function setUpController(): void
     {
-        return [];
+        parent::setUpController();
+        $this->enableAugmentedModel();
+        $this->enableShowImage();
+        $this->setTitleColumnKey('fullTitle');
+        $this->setModuleName('artworks');
+    }
+
+    protected function additionalIndexTableColumns(): TableColumns
+    {
+        $columns = TableColumns::make();
+        $columns->add(
+            Text::make()
+                ->title('Reference number')
+                ->field('main_reference_number')
+                ->optional()
+        );
+        $columns->add(
+            Text::make()
+                ->title('Artist')
+                ->field('artist_display')
+                ->optional()
+        );
+        return $columns;
     }
 
     protected function formData($request)
@@ -80,7 +48,7 @@ class ArtworkController extends \App\Http\Controllers\Twill\BaseApiController
         ];
     }
 
-    public function browser(): \Illuminate\Http\JsonResponse
+    public function browser(): JsonResponse
     {
         // Allow to filter by IDS when listing artworks.
         return response()->json($this->getBrowserData(['id' => request('artwork_ids')]));

--- a/app/Http/Controllers/Twill/EmailSeriesController.php
+++ b/app/Http/Controllers/Twill/EmailSeriesController.php
@@ -2,11 +2,12 @@
 
 namespace App\Http\Controllers\Twill;
 
-class EmailSeriesController extends \App\Http\Controllers\Twill\ModuleController
+class EmailSeriesController extends BaseController
 {
-    protected $moduleName = 'emailSeries';
-
-    protected $indexOptions = [
-        'reorder' => true,
-    ];
+    protected function setUpController(): void
+    {
+        parent::setUpController();
+        $this->enableReorder();
+        $this->setModuleName('emailSeries');
+    }
 }

--- a/app/Http/Controllers/Twill/LandingPageController.php
+++ b/app/Http/Controllers/Twill/LandingPageController.php
@@ -3,32 +3,20 @@
 namespace App\Http\Controllers\Twill;
 
 use A17\Twill\Models\Contracts\TwillModelContract;
+use A17\Twill\Services\Listings\Columns\Text;
+use A17\Twill\Services\Listings\TableColumns;
 use App\Http\Controllers\LandingPagesController;
 use App\Models\LandingPage;
 use App\Repositories\LandingPageRepository;
 
-class LandingPageController extends \App\Http\Controllers\Twill\ModuleController
+class LandingPageController extends BaseController
 {
-    protected $moduleName = 'landingPages';
-
-    protected $indexColumns = [
-        'title' => [
-            'title' => 'Title',
-            'edit_link' => true,
-            'sort' => true,
-            'field' => 'title',
-        ],
-        'type' => [
-            'title' => 'Type',
-            'field' => 'type',
-        ],
-    ];
-
-    protected $indexWith = [];
-
-    protected $defaultOrders = [];
-
-    protected $previewView = 'site.landingPageDetail';
+    protected function setUpController(): void
+    {
+        parent::setUpController();
+        $this->setModuleName('landingPages');
+        $this->setPreviewView('site.landingPageDetail');
+    }
 
     /**
      * Dynamically set the view prefix to include the landing page type.
@@ -37,7 +25,7 @@ class LandingPageController extends \App\Http\Controllers\Twill\ModuleController
     {
         $landingPage = $this->repository->getById($id);
         $prefix = str($landingPage->type)->camel();
-        $this->viewPrefix = "admin.$this->moduleName.$prefix";
+        $this->viewPrefix = config('twill.admin_route_name_prefix') . "$this->moduleName.$prefix";
         return parent::edit($id, $submoduleId);
     }
 
@@ -49,6 +37,18 @@ class LandingPageController extends \App\Http\Controllers\Twill\ModuleController
             'defaultType' => $types->search(LandingPage::DEFAULT_TYPE),
             'types' => $types->sort(),
         ];
+    }
+
+    protected function additionalIndexTableColumns(): TableColumns
+    {
+        $columns = TableColumns::make();
+        $columns->add(
+            Text::make()
+                ->field('type')
+                ->optional()
+        );
+
+        return $columns;
     }
 
     protected function formData($request)

--- a/app/Http/Controllers/Twill/MagazineIssueController.php
+++ b/app/Http/Controllers/Twill/MagazineIssueController.php
@@ -2,39 +2,19 @@
 
 namespace App\Http\Controllers\Twill;
 
-class MagazineIssueController extends \App\Http\Controllers\Twill\ModuleController
-{
-    protected $moduleName = 'magazineIssues';
+use A17\Twill\Services\Listings\Columns\Text;
+use A17\Twill\Services\Listings\TableColumns;
 
+class MagazineIssueController extends BaseController
+{
     protected $permalinkBase = 'magazine/issues/';
 
-    protected $indexColumns = [
-        'image' => [
-            'title' => 'Hero',
-            'thumb' => true,
-            'variant' => [
-                'role' => 'hero',
-                'crop' => 'default',
-            ],
-        ],
-        'title' => [
-            'title' => 'Title',
-            'edit_link' => true,
-            'sort' => true,
-            'field' => 'title',
-        ],
-        'date' => [
-            'title' => 'Publish Date',
-            'edit_link' => true,
-            'sort' => true,
-            'field' => 'publish_start_date',
-            'present' => true,
-        ],
-    ];
-
-    protected $defaultOrders = [
-        'publish_start_date' => 'desc',
-    ];
+    protected function setUpController(): void
+    {
+        parent::setUpController();
+        $this->enableShowImage();
+        $this->setModuleName('magazineIssues');
+    }
 
     protected function formData($request)
     {

--- a/app/Http/Controllers/Twill/MiradorController.php
+++ b/app/Http/Controllers/Twill/MiradorController.php
@@ -2,10 +2,14 @@
 
 namespace App\Http\Controllers\Twill;
 
-class MiradorController extends \App\Http\Controllers\Twill\ModuleController
+class MiradorController extends BaseController
 {
-    protected $moduleName = 'miradors';
-    protected $previewView = 'site.miradorDetail';
+    protected function setUpController(): void
+    {
+        parent::setUpController();
+        $this->setModuleName('miradors');
+        $this->setPreviewView('site.miradorDetail');
+    }
 
     protected function formData($request)
     {

--- a/app/Http/Controllers/Twill/SponsorController.php
+++ b/app/Http/Controllers/Twill/SponsorController.php
@@ -2,44 +2,11 @@
 
 namespace App\Http\Controllers\Twill;
 
-class SponsorController extends \App\Http\Controllers\Twill\ModuleController
+class SponsorController extends BaseController
 {
-    protected $moduleName = 'sponsors';
-
-    protected $indexColumns = [
-        'title' => [
-            'title' => 'Title',
-            'edit_link' => true,
-            'sort' => true,
-            'field' => 'title',
-        ],
-    ];
-
-    /**
-     * Relations to eager load for the index view
-     */
-    protected $indexWith = [];
-
-    /**
-     * Relations to eager load for the form view
-     */
-    protected $formWith = [];
-
-    /**
-     * Filters mapping ('filterName' => 'filterColumn')
-     * In the indexData function, name your lists with the filter name + List (filterNameList)
-     */
-    protected $filters = [];
-
-    protected $defaultOrders = ['title' => 'asc'];
-
-    protected function indexData($request)
+    protected function setUpController(): void
     {
-        return [];
-    }
-
-    protected function formData($request)
-    {
-        return [];
+        parent::setUpController();
+        $this->setModuleName('sponsors');
     }
 }

--- a/app/Models/Api/Artist.php
+++ b/app/Models/Api/Artist.php
@@ -3,10 +3,13 @@
 namespace App\Models\Api;
 
 use Aic\Hub\Foundation\Library\Api\Models\BaseApiModel;
+use Aic\Hub\Foundation\Library\Api\Models\Behaviors\HasMediasApi;
 use App\Helpers\StringHelpers;
 
 class Artist extends BaseApiModel
 {
+    use HasMediasApi;
+
     protected array $endpoints = [
         'collection' => '/api/v1/artists',
         'resource' => '/api/v1/artists/{id}',

--- a/app/Models/Api/Exhibition.php
+++ b/app/Models/Api/Exhibition.php
@@ -8,14 +8,15 @@ use Aic\Hub\Foundation\Library\Api\Models\BaseApiModel;
 use Aic\Hub\Foundation\Library\Api\Builders\ApiModelBuilder;
 use App\Helpers\StringHelpers;
 use Aic\Hub\Foundation\Library\Api\Models\Behaviors\HasApiFactory;
+use Aic\Hub\Foundation\Library\Api\Models\Behaviors\HasMediasApi;
 
 class Exhibition extends BaseApiModel
 {
     use HasFeaturedRelated {
         getCustomRelatedItems as traitGetCustomRelatedItems;
     }
-
     use HasApiFactory;
+    use HasMediasApi;
 
     protected array $endpoints = [
         'collection' => '/api/v1/exhibitions',

--- a/app/Repositories/MagazineIssueRepository.php
+++ b/app/Repositories/MagazineIssueRepository.php
@@ -10,6 +10,7 @@ use A17\Twill\Repositories\Behaviors\HandleBlocks;
 use A17\Twill\Repositories\Behaviors\HandleMedias;
 use A17\Twill\Repositories\Behaviors\HandleRevisions;
 use App\Repositories\Behaviors\HandleApiBlocks;
+use Illuminate\Database\Eloquent\Builder;
 
 class MagazineIssueRepository extends ModuleRepository
 {
@@ -26,6 +27,14 @@ class MagazineIssueRepository extends ModuleRepository
     public function __construct(MagazineIssue $model)
     {
         $this->model = $model;
+    }
+
+    public function order(Builder $query, array $orders = []): Builder
+    {
+        // Default sort by publish_start_date instead of created_at.
+        $orders['publish_start_date'] ??= 'desc';
+        unset($orders['created_at']);
+        return parent::order($query, $orders);
     }
 
     public function getLatestIssue(): MagazineIssue

--- a/app/Repositories/SponsorRepository.php
+++ b/app/Repositories/SponsorRepository.php
@@ -4,6 +4,7 @@ namespace App\Repositories;
 
 use A17\Twill\Repositories\Behaviors\HandleBlocks;
 use App\Models\Sponsor;
+use Illuminate\Database\Eloquent\Builder;
 
 class SponsorRepository extends ModuleRepository
 {
@@ -12,5 +13,13 @@ class SponsorRepository extends ModuleRepository
     public function __construct(Sponsor $model)
     {
         $this->model = $model;
+    }
+
+    public function order(Builder $query, array $orders = []): Builder
+    {
+        // Default sort by title instead of created_at.
+        $orders['title'] ??= 'asc';
+        unset($orders['created_at']);
+        return parent::order($query, $orders);
     }
 }


### PR DESCRIPTION
This work replaces the `$indexColumns` array in Twill controllers with a `getIndexTableColumns()` and `setUpController()` methods that allow us to have more control over how the Twill admin displays the index table.