### PR TITLE
Twill index tables - Exhibitions & Events

### DIFF
--- a/app/Http/Controllers/Twill/EmailSeriesController.php
+++ b/app/Http/Controllers/Twill/EmailSeriesController.php
@@ -2,11 +2,12 @@
 
 namespace App\Http\Controllers\Twill;
 
-class EmailSeriesController extends \App\Http\Controllers\Twill\ModuleController
+class EmailSeriesController extends BaseController
 {
-    protected $moduleName = 'emailSeries';
-
-    protected $indexOptions = [
-        'reorder' => true,
-    ];
+    protected function setUpController(): void
+    {
+        parent::setUpController();
+        $this->enableReorder();
+        $this->setModuleName('emailSeries');
+    }
 }

--- a/app/Http/Controllers/Twill/EventController.php
+++ b/app/Http/Controllers/Twill/EventController.php
@@ -2,7 +2,7 @@
 
 namespace App\Http\Controllers\Twill;
 
-use A17\Twill\Services\Listings\Columns\Text;
+use A17\Twill\Services\Listings\Columns\Presenter;
 use A17\Twill\Services\Listings\TableColumns;
 use App\Models\Event;
 use App\Repositories\EventProgramRepository;
@@ -12,7 +12,6 @@ class EventController extends BaseController
     protected function setUpController(): void
     {
         $this->eagerLoadFormRelations(['revisions', 'dateRules']);
-        $this->eagerLoadListingRelations(['medias']); // I don't believe this is necessary anymore
         $this->enableBulkFeature();
         $this->enableDuplicate();
         $this->enableFeature();
@@ -27,30 +26,13 @@ class EventController extends BaseController
     {
         $columns = new TableColumns();
         $columns->add(
-            Text::make()
+            Presenter::make()
                 ->field('formattedNextOccurrence')
                 ->title('Event Date')
                 ->sortable()
-                ->customRender(self::renderDate(...))
         );
 
         return $columns;
-    }
-
-    private function renderDate(Event $event)
-    {
-        if (!empty($event->forced_date)) {
-            return $event->forced_date;
-        }
-
-        if ($next = $event->nextOccurrenceExclusive) {
-            return '<time datetime="' . $next->date->format('c') . '" itemprop="startDate">' . $next->date->format('F j, Y | g:i') . '</time>&ndash;<time datetime="' . $next->date_end->format('c') . '" itemprop="endDate">' . $next->date_end->format('g:i') . '</time>';
-        }
-
-        if ($last = $event->lastOccurrence) {
-            return '<time datetime="' . $last->date->format('c') . '" itemprop="startDate">' . $last->date->format('F j, Y | g:i') . '</time>&ndash;<time datetime="' . $last->date_end->format('c') . '" itemprop="endDate">' . $last->date_end->format('g:i') . '</time>';
-        }
-        return '';
     }
 
     /**

--- a/app/Http/Controllers/Twill/ExhibitionController.php
+++ b/app/Http/Controllers/Twill/ExhibitionController.php
@@ -2,9 +2,8 @@
 
 namespace App\Http\Controllers\Twill;
 
-use A17\Twill\Services\Listings\Columns\Text;
+use A17\Twill\Services\Listings\Columns\Presenter;
 use A17\Twill\Services\Listings\TableColumns;
-use App\Models\Api\Exhibition;
 use App\Repositories\Api\ExhibitionRepository;
 use App\Repositories\SiteTagRepository;
 
@@ -19,13 +18,7 @@ class ExhibitionController extends BaseApiController
         $this->disableEdit();
         $this->disableRestore();
         $this->eagerLoadFormRelations(['revisions', 'siteTags']);
-        // I believe this was meant to load local images (as opposed to from the
-        // api), but this no longer seems to work.
-        $this->eagerLoadListingRelations(['medias']);
         $this->enableAugmentedModel();
-        // The images don't always render, but this was also an issue before
-        // upgrading.
-        $this->enableShowImage();
         $this->setModuleName('exhibitions');
         $this->setPreviewView('site.exhibitionDetail');
     }
@@ -34,42 +27,14 @@ class ExhibitionController extends BaseApiController
     {
         $columns = TableColumns::make();
         $columns->add(
-            Text::make()
+            Presenter::make()
                 ->title('Dates')
                 ->field('date')
                 ->sortable()
                 ->sortKey('aic_start_at')
                 ->sortByDefault(direction: 'desc')
-                ->customRender(self::renderDate(...))
         );
         return $columns;
-    }
-
-    protected function renderDate(Exhibition $exhibition)
-    {
-        $date = '';
-
-        // Strangely, we cannot use isset() or empty() here
-        $hasStart = $exhibition->aic_start_at !== null;
-        $hasEnd = $exhibition->aic_end_at !== null;
-
-        // These default gracefully to `now` if the attrs are empty
-        $start = $exhibition->asDateTime($exhibition->aic_start_at);
-        $end = $exhibition->asDateTime($exhibition->aic_end_at);
-
-        if ($hasStart) {
-            $date .= $start->format('m d Y');
-        }
-
-        if ($hasStart && $hasEnd) {
-            $date .= '–';
-        }
-
-        if ($hasEnd) {
-            $date .= $end->format('m d Y');
-        }
-
-        return $date;
     }
 
     protected function formData($request)

--- a/app/Http/Controllers/Twill/MagazineIssueController.php
+++ b/app/Http/Controllers/Twill/MagazineIssueController.php
@@ -2,39 +2,19 @@
 
 namespace App\Http\Controllers\Twill;
 
-class MagazineIssueController extends \App\Http\Controllers\Twill\ModuleController
-{
-    protected $moduleName = 'magazineIssues';
+use A17\Twill\Services\Listings\Columns\Text;
+use A17\Twill\Services\Listings\TableColumns;
 
+class MagazineIssueController extends BaseController
+{
     protected $permalinkBase = 'magazine/issues/';
 
-    protected $indexColumns = [
-        'image' => [
-            'title' => 'Hero',
-            'thumb' => true,
-            'variant' => [
-                'role' => 'hero',
-                'crop' => 'default',
-            ],
-        ],
-        'title' => [
-            'title' => 'Title',
-            'edit_link' => true,
-            'sort' => true,
-            'field' => 'title',
-        ],
-        'date' => [
-            'title' => 'Publish Date',
-            'edit_link' => true,
-            'sort' => true,
-            'field' => 'publish_start_date',
-            'present' => true,
-        ],
-    ];
-
-    protected $defaultOrders = [
-        'publish_start_date' => 'desc',
-    ];
+    protected function setUpController(): void
+    {
+        parent::setUpController();
+        $this->enableShowImage();
+        $this->setModuleName('magazineIssues');
+    }
 
     protected function formData($request)
     {

--- a/app/Http/Controllers/Twill/MiradorController.php
+++ b/app/Http/Controllers/Twill/MiradorController.php
@@ -2,10 +2,14 @@
 
 namespace App\Http\Controllers\Twill;
 
-class MiradorController extends \App\Http\Controllers\Twill\ModuleController
+class MiradorController extends BaseController
 {
-    protected $moduleName = 'miradors';
-    protected $previewView = 'site.miradorDetail';
+    protected function setUpController(): void
+    {
+        parent::setUpController();
+        $this->setModuleName('miradors');
+        $this->setPreviewView('site.miradorDetail');
+    }
 
     protected function formData($request)
     {

--- a/app/Http/Controllers/Twill/SponsorController.php
+++ b/app/Http/Controllers/Twill/SponsorController.php
@@ -2,44 +2,11 @@
 
 namespace App\Http\Controllers\Twill;
 
-class SponsorController extends \App\Http\Controllers\Twill\ModuleController
+class SponsorController extends BaseController
 {
-    protected $moduleName = 'sponsors';
-
-    protected $indexColumns = [
-        'title' => [
-            'title' => 'Title',
-            'edit_link' => true,
-            'sort' => true,
-            'field' => 'title',
-        ],
-    ];
-
-    /**
-     * Relations to eager load for the index view
-     */
-    protected $indexWith = [];
-
-    /**
-     * Relations to eager load for the form view
-     */
-    protected $formWith = [];
-
-    /**
-     * Filters mapping ('filterName' => 'filterColumn')
-     * In the indexData function, name your lists with the filter name + List (filterNameList)
-     */
-    protected $filters = [];
-
-    protected $defaultOrders = ['title' => 'asc'];
-
-    protected function indexData($request)
+    protected function setUpController(): void
     {
-        return [];
-    }
-
-    protected function formData($request)
-    {
-        return [];
+        parent::setUpController();
+        $this->setModuleName('sponsors');
     }
 }

--- a/app/Models/Api/Exhibition.php
+++ b/app/Models/Api/Exhibition.php
@@ -8,14 +8,15 @@ use Aic\Hub\Foundation\Library\Api\Models\BaseApiModel;
 use Aic\Hub\Foundation\Library\Api\Builders\ApiModelBuilder;
 use App\Helpers\StringHelpers;
 use Aic\Hub\Foundation\Library\Api\Models\Behaviors\HasApiFactory;
+use Aic\Hub\Foundation\Library\Api\Models\Behaviors\HasMediasApi;
 
 class Exhibition extends BaseApiModel
 {
     use HasFeaturedRelated {
         getCustomRelatedItems as traitGetCustomRelatedItems;
     }
-
     use HasApiFactory;
+    use HasMediasApi;
 
     protected array $endpoints = [
         'collection' => '/api/v1/exhibitions',

--- a/app/Repositories/MagazineIssueRepository.php
+++ b/app/Repositories/MagazineIssueRepository.php
@@ -10,6 +10,7 @@ use A17\Twill\Repositories\Behaviors\HandleBlocks;
 use A17\Twill\Repositories\Behaviors\HandleMedias;
 use A17\Twill\Repositories\Behaviors\HandleRevisions;
 use App\Repositories\Behaviors\HandleApiBlocks;
+use Illuminate\Database\Eloquent\Builder;
 
 class MagazineIssueRepository extends ModuleRepository
 {
@@ -26,6 +27,14 @@ class MagazineIssueRepository extends ModuleRepository
     public function __construct(MagazineIssue $model)
     {
         $this->model = $model;
+    }
+
+    public function order(Builder $query, array $orders = []): Builder
+    {
+        // Default sort by publish_start_date instead of created_at.
+        $orders['publish_start_date'] ??= 'desc';
+        unset($orders['created_at']);
+        return parent::order($query, $orders);
     }
 
     public function getLatestIssue(): MagazineIssue

--- a/app/Repositories/SponsorRepository.php
+++ b/app/Repositories/SponsorRepository.php
@@ -4,6 +4,7 @@ namespace App\Repositories;
 
 use A17\Twill\Repositories\Behaviors\HandleBlocks;
 use App\Models\Sponsor;
+use Illuminate\Database\Eloquent\Builder;
 
 class SponsorRepository extends ModuleRepository
 {
@@ -12,5 +13,13 @@ class SponsorRepository extends ModuleRepository
     public function __construct(Sponsor $model)
     {
         $this->model = $model;
+    }
+
+    public function order(Builder $query, array $orders = []): Builder
+    {
+        // Default sort by title instead of created_at.
+        $orders['title'] ??= 'asc';
+        unset($orders['created_at']);
+        return parent::order($query, $orders);
     }
 }


### PR DESCRIPTION
Updates to the index tables for pages under the Exhibitions & Events tab:
- Exhibitions
- Events
- Sponsors
- Email Series
- Magazine Issues
- Mirador