### PR TITLE
Twill index tables - Pages

### DIFF
--- a/app/Http/Controllers/Twill/ExhibitionPressRoomController.php
+++ b/app/Http/Controllers/Twill/ExhibitionPressRoomController.php
@@ -2,10 +2,13 @@
 
 namespace App\Http\Controllers\Twill;
 
-class ExhibitionPressRoomController extends \App\Http\Controllers\Twill\ModuleController
+class ExhibitionPressRoomController extends BaseController
 {
-    protected $moduleName = 'exhibitionPressRooms';
-    protected $previewView = 'site.genericPage.show';
+    protected function setUpController(): void
+    {
+        $this->setModuleName('exhibitionPressRooms');
+        $this->setPreviewView('site.genericPage.show');
+    }
 
     protected function formData($request)
     {

--- a/app/Http/Controllers/Twill/GenericPageController.php
+++ b/app/Http/Controllers/Twill/GenericPageController.php
@@ -4,39 +4,14 @@ namespace App\Http\Controllers\Twill;
 
 use App\Repositories\PageCategoryRepository;
 
-class GenericPageController extends \App\Http\Controllers\Twill\ModuleController
+class GenericPageController extends BaseController
 {
-    protected $moduleName = 'genericPages';
-    protected $previewView = 'site.genericPage.show';
-
-    protected $indexColumns = [
-        'title' => [
-            'title' => 'Title',
-            'field' => 'title',
-            'sort' => true,
-        ],
-    ];
-
-    protected $indexOptions = [
-        'reorder' => true,
-        'permalink' => true,
-    ];
-
-    /**
-     * Relations to eager load for the index view
-     */
-    protected $indexWith = [];
-
-    /**
-     * Relations to eager load for the form view
-     */
-    protected $formWith = [];
-
-    /**
-     * Filters mapping ('filterName' => 'filterColumn')
-     * In the indexData function, name your lists with the filter name + List (filterNameList)
-     */
-    protected $filters = [];
+    protected function setUpController(): void
+    {
+        $this->enableReorder();
+        $this->setModuleName('genericPages');
+        $this->setPreviewView('site.genericPage.show');
+    }
 
     /**
      * Exposed as public for sitemap:generate command.

--- a/app/Http/Controllers/Twill/LandingPageController.php
+++ b/app/Http/Controllers/Twill/LandingPageController.php
@@ -3,32 +3,30 @@
 namespace App\Http\Controllers\Twill;
 
 use A17\Twill\Models\Contracts\TwillModelContract;
+use A17\Twill\Services\Listings\Columns\Text;
+use A17\Twill\Services\Listings\TableColumns;
 use App\Http\Controllers\LandingPagesController;
 use App\Models\LandingPage;
 use App\Repositories\LandingPageRepository;
 
-class LandingPageController extends \App\Http\Controllers\Twill\ModuleController
+class LandingPageController extends BaseController
 {
-    protected $moduleName = 'landingPages';
+    protected function setUpController(): void
+    {
+        $this->setModuleName('landingPages') ;
+        $this->setPreviewView('site.landingPageDetail');
+    }
 
-    protected $indexColumns = [
-        'title' => [
-            'title' => 'Title',
-            'edit_link' => true,
-            'sort' => true,
-            'field' => 'title',
-        ],
-        'type' => [
-            'title' => 'Type',
-            'field' => 'type',
-        ],
-    ];
+    protected function additionalIndexTableColumns(): TableColumns
+    {
+        $columns = TableColumns::make();
+        $columns->add(
+            Text::make()
+                ->field('type')
+        );
 
-    protected $indexWith = [];
-
-    protected $defaultOrders = [];
-
-    protected $previewView = 'site.landingPageDetail';
+        return $columns;
+    }
 
     /**
      * Dynamically set the view prefix to include the landing page type.

--- a/app/Http/Controllers/Twill/PressReleaseController.php
+++ b/app/Http/Controllers/Twill/PressReleaseController.php
@@ -2,27 +2,30 @@
 
 namespace App\Http\Controllers\Twill;
 
-class PressReleaseController extends \App\Http\Controllers\Twill\ModuleController
+use A17\Twill\Services\Listings\Columns\Presenter;
+use A17\Twill\Services\Listings\TableColumns;
+
+class PressReleaseController extends BaseController
 {
-    protected $moduleName = 'pressReleases';
-    protected $previewView = 'site.genericPage.show';
+    protected function setUpController(): void
+    {
+        $this->setModuleName('pressReleases');
+        $this->setPreviewView('site.genericPage.show');
+    }
 
-    protected $defaultOrders = ['publish_start_date' => 'desc'];
+    protected function additionalIndexTableColumns(): TableColumns
+    {
+        $columns = TableColumns::make();
+        $columns->add(
+            Presenter::make()
+                ->field('presentPublishStartDate')
+                ->title('Publish Date')
+                ->sortable()
+                ->sortKey('publish_start_date')
+        );
 
-    protected $indexColumns = [
-        'title' => [
-            'field' => 'title',
-            'title' => 'Title',
-        ],
-        // The key must equal the field, else sortKey cannot be reached
-        'presentPublishStartDate' => [
-            'title' => 'Publish Date',
-            'present' => true,
-            'field' => 'presentPublishStartDate',
-            'sort' => true,
-            'sortKey' => 'publish_start_date',
-        ],
-    ];
+        return $columns;
+    }
 
     protected function formData($request)
     {

--- a/app/Repositories/PressReleaseRepository.php
+++ b/app/Repositories/PressReleaseRepository.php
@@ -10,6 +10,7 @@ use A17\Twill\Repositories\Behaviors\HandleRevisions;
 use A17\Twill\Repositories\Behaviors\HandleSlugs;
 use App\Models\PressRelease;
 use App\Models\Api\Search;
+use Illuminate\Database\Eloquent\Builder;
 
 class PressReleaseRepository extends ModuleRepository
 {
@@ -28,6 +29,14 @@ class PressReleaseRepository extends ModuleRepository
     public function __construct(PressRelease $model)
     {
         $this->model = $model;
+    }
+
+    public function order(Builder $query, array $orders = []): Builder
+    {
+        $orders['publish_start_date'] ??= 'desc';
+        unset($orders['created_at']);
+
+        return parent::order($query, $orders);
     }
 
     public function hydrate(TwillModelContract $object, array $fields): TwillModelContract


### PR DESCRIPTION
Updates to some of the index tables for pages under the Pages tab:

- [ ] Landing Pages
- [ ] Generic Pages
- [ ] Press Releases
- [ ] Exhibition Press Rooms

Not included:
Page Features -- this functionality does not appear to be in use