### PR TITLE
Twill upgrade - missed controllers

### DIFF
--- a/app/Http/Controllers/Twill/BaseController.php
+++ b/app/Http/Controllers/Twill/BaseController.php
@@ -15,7 +15,7 @@ class BaseController extends ModuleController
     public function edit(TwillModelContract|int $id): mixed
     {
         $view = parent::edit($id);
-        if (!$this->indexOptions['editInModal']) {
+        if (!$this->getIndexOption('editInModal')) {
             $view = $view->with([
                 'editableTitle' =>
                     $this->repository->isFillable($this->titleColumnKey)

--- a/app/Http/Controllers/Twill/Behaviors/IsNestedModule.php
+++ b/app/Http/Controllers/Twill/Behaviors/IsNestedModule.php
@@ -47,4 +47,9 @@ trait IsNestedModule
             ] : []);
         })->toArray();
     }
+
+    protected function setPreviewView(string $previewView): void
+    {
+        $this->previewView = $previewView;
+    }
 }

--- a/app/Http/Controllers/Twill/DigitalPublicationArticleController.php
+++ b/app/Http/Controllers/Twill/DigitalPublicationArticleController.php
@@ -3,37 +3,37 @@
 namespace App\Http\Controllers\Twill;
 
 use A17\Twill\Http\Controllers\Admin\NestedModuleController;
-use App\Repositories\DigitalPublicationRepository;
+use A17\Twill\Services\Listings\Columns\Presenter;
+use A17\Twill\Services\Listings\TableColumns;
 use App\Http\Controllers\Twill\Behaviors\IsNestedModule;
-use Illuminate\Support\Collection;
+use App\Repositories\DigitalPublicationRepository;
 
 class DigitalPublicationArticleController extends NestedModuleController
 {
-    use \App\Http\Controllers\Twill\Behaviors\IsNestedModule;
-
-    protected $moduleName = 'digitalPublications.articles';
-    protected $modelName = 'DigitalPublicationArticle';
-    protected $previewView = 'site.digitalPublicationArticleDetail';
+    use IsNestedModule;
 
     protected $permalinkBase = 'digital-publications/';
 
-    protected $indexOptions = [
-        'permalink' => true,
-        'reorder' => true,
-    ];
+    protected function setUpController(): void
+    {
+        parent::setUpController();
+        $this->enableReorder();
+        $this->setModelName('DigitalPublicationArticle');
+        $this->setModuleName('digitalPublications.articles');
+        $this->setPreviewView('site.digitalPublicationArticleDetail');
+    }
 
-    protected $indexColumns = [
-        'title' => [
-            'title' => 'Title',
-            'edit_link' => true,
-            'field' => 'title',
-        ],
-        'article_type' => [
-            'title' => 'Type',
-            'field' => 'articleType',
-            'present' => true,
-        ],
-    ];
+    protected function additionalIndexTableColumns(): TableColumns
+    {
+        $columns = TableColumns::make();
+        $columns->add(
+            Presenter::make()
+                ->field('articleType')
+                ->title('Type')
+        );
+
+        return $columns;
+    }
 
     protected function getParentModuleForeignKey()
     {

--- a/app/Http/Controllers/Twill/ExperienceSlideController.php
+++ b/app/Http/Controllers/Twill/ExperienceSlideController.php
@@ -6,21 +6,21 @@ use App\Models\Article;
 use App\Repositories\ExperienceRepository;
 use App\Repositories\SlideRepository;
 
-class ExperienceSlideController extends \App\Http\Controllers\Twill\ModuleController
+class ExperienceSlideController extends BaseController
 {
-    protected $moduleName = 'experiences.slides';
-    protected $modelName = 'Slide';
-    protected $previewView = 'site.experienceDetail';
+    protected function setUpController(): void
+    {
+        parent::setUpController();
+        $this->enableReorder();
+        $this->setModelName('Slide');
+        $this->setModuleName('experiences.slides');
+        $this->setPreviewView('site.experienceDetail');
+    }
 
     protected function getParentModuleForeignKey()
     {
         return 'experience_id';
     }
-
-    protected $indexOptions = [
-        'reorder' => true,
-        'permalink' => false,
-    ];
 
     protected function indexData($request)
     {

--- a/app/Http/Controllers/Twill/ExperienceSlideController.php
+++ b/app/Http/Controllers/Twill/ExperienceSlideController.php
@@ -2,6 +2,8 @@
 
 namespace App\Http\Controllers\Twill;
 
+use A17\Twill\Services\Listings\Columns\Text;
+use A17\Twill\Services\Listings\TableColumns;
 use App\Models\Article;
 use App\Repositories\ExperienceRepository;
 use App\Repositories\SlideRepository;
@@ -15,6 +17,22 @@ class ExperienceSlideController extends BaseController
         $this->setModelName('Slide');
         $this->setModuleName('experiences.slides');
         $this->setPreviewView('site.experienceDetail');
+    }
+
+    // Replace the default title field with an unsortable version.
+    protected function getIndexTableColumns(): TableColumns
+    {
+        $columns = parent::getIndexTableColumns();
+        return $columns->map(function ($column) {
+            if ($column->getKey() == $this->titleColumnKey) {
+                $column = Text::make()
+                    ->field($this->titleColumnKey)
+                    ->title($this->titleColumnLabel)
+                    ->linkToEdit()
+                    ->sortable(false);
+            }
+            return $column;
+        });
     }
 
     protected function getParentModuleForeignKey()


### PR DESCRIPTION
I missed updating the `DigitalPublicationArticleController` and `ExperienceSlideController` because they don't have dedicated tabs in the menu, but are linked to from their parents' index tables.