### PR TITLE
Fix imageFront calls [WEB-2984]

### DIFF
--- a/app/Models/Api/Exhibition.php
+++ b/app/Models/Api/Exhibition.php
@@ -37,6 +37,11 @@ class Exhibition extends BaseApiModel
      */
     public const SEARCH_FIELDS = ['id', 'title', 'status', 'aic_start_at', 'aic_end_at', 'is_boosted', 'thumbnail', 'short_description', 'gallery_title', 'gallery_id', 'image_id', 'api_model'];
 
+    // Don't define the mediasParams here, so it will fall back to the augmented model
+    public $mediasParams = [
+        'null' => [],
+    ];
+
     /**
      * Generates the id-slug type of URL
      */


### PR DESCRIPTION
For some reason, when [resources/views/site/blocks/feature_block.blade.php](../blob/feature/twill-upgrade/resources/views/site/blocks/feature_block.blade.php) calls `imageFront` on an API model that doesn't have `$mediaParams` defined, it throws an error that reads `Cannot end a section without first starting one`. But the Exception is being thrown from [HasMediasApi](https://github.com/art-institute-of-chicago/data-hub-foundation/blob/develop/src/Library/Api/Models/Behaviors/HasMediasApi.php#L62):

```
if (empty($this->mediasParams)) {
    throw new \Exception('You have to define $mediasParams when using imageFront');
}
```

The Exhibition model is typically augmented, and images are associated with it in the CMS. So, we don't want to rely on an API image field but allow the request to fall back to the augmented model to retrieve the image. This PR effectively adds a blank `$mediaParams` attribute. It can't truly be empty, though, because the noted exception will be thrown.
