### PR TITLE
Add method to LP model to overwrite generated slugs if set

### DIFF
--- a/app/Models/LandingPage.php
+++ b/app/Models/LandingPage.php
@@ -369,6 +369,11 @@ class LandingPage extends AbstractModel implements Sortable
         return $this->belongsToMany(\App\Models\GenericPage::class, 'landing_page_generic_pages')->withPivot('position')->orderBy('landing_page_generic_pages.position', 'asc');
     }
 
+    public function shouldGenerateSlugOnSave()
+    {
+        return empty($this->slug);
+    }
+
     public function landingPageSlug()
     {
         return $this->hasOne(LandingPageSlug::class, 'slug');


### PR DESCRIPTION
So in our twill updates the HandleSlugs trait added auto generation from title as the default behavior. This breaks any custom slugs we set like 'Articles & Videos' because it then gets set to '/article-videos'. Without this method set in the model it'll always default to it. This is a fix just for LP's but we could also set this as default behavior in the HandleSlugs trait.