### PR TITLE
Moved image-related method into `ImageHelpers`

### DIFF
--- a/app/Helpers/ImageHelpers.php
+++ b/app/Helpers/ImageHelpers.php
@@ -680,6 +680,7 @@ class ImageHelpers
 
         return Str::kebab($icons[$key]);
     }
+
     public static function getSocialIcon($url)
     {
         $host = parse_url($url, PHP_URL_HOST);
@@ -687,5 +688,15 @@ class ImageHelpers
         $domains = explode('.', $host);
         // The second-to-last domain item is the host domain
         return $domains[count($domains) - 2] ?? null;
+    }
+
+    /**
+     * @link https://github.com/openseadragon/openseadragon/pull/1285/files
+     */
+    public static function getImgixTileSource($model, $role, $crop = 'default')
+    {
+        if ($media = $model->imageObject($role, $crop)) {
+            return 'https://' . config('twill.imgix_source_host') . '/' . $media->uuid . '?fm=json&osd=imgix';
+        }
     }
 }

--- a/app/Models/Vendor/Block.php
+++ b/app/Models/Vendor/Block.php
@@ -43,16 +43,4 @@ class Block extends BaseModel
 
         return null;
     }
-
-    /**
-     * @link https://github.com/openseadragon/openseadragon/pull/1285/files
-     */
-    public function getImgixTileSource($role, $crop = 'default')
-    {
-        $media = $this->findMedia($role, $crop);
-
-        if ($media) {
-            return 'https://' . config('twill.imgix_source_host') . '/' . $media->uuid . '?fm=json&osd=imgix';
-        }
-    }
 }

--- a/resources/views/site/blocks/gallery_new.blade.php
+++ b/resources/views/site/blocks/gallery_new.blade.php
@@ -99,7 +99,7 @@
 
                 if (($block->input('is_gallery_zoomable') ?? false) || $item->input('is_zoomable')) {
                     if (isset($mediaItem['media'])) {
-                        $mediaItem['media']['iiifId'] = $item->getImgixTileSource('image', 'desktop');
+                        $mediaItem['media']['iiifId'] = \App\Helpers\ImageHelpers::getImgixTileSource($item, 'image', 'desktop');
                     }
                 }
 

--- a/resources/views/site/blocks/image.blade.php
+++ b/resources/views/site/blocks/image.blade.php
@@ -34,7 +34,7 @@
                 'restrict' => $image['restict'] ?? false,
                 'fullscreen' => $isZoomable,
                 'iiifId' => $isZoomable
-                    ? $block->getImgixTileSource('image', 'desktop')
+                    ? \App\Helpers\ImageHelpers::getImgixTileSource($block, 'image', 'desktop')
                     : null,
             ],
             'showUrl' => !empty($block->input('image_link')),

--- a/resources/views/site/blocks/image_slider.blade.php
+++ b/resources/views/site/blocks/image_slider.blade.php
@@ -1,6 +1,6 @@
 @php
-    $leftImage = $block->getImgixTileSource('left_image');
-    $rightImage = $block->getImgixTileSource('right_image');
+    $leftImage = \App\Helpers\ImageHelpers::getImgixTileSource($block, 'left_image');
+    $rightImage = \App\Helpers\ImageHelpers::getImgixTileSource($block, 'right_image');
 
     $referenceImage = $block->imageAsArray('left_image', 'default');
 @endphp


### PR DESCRIPTION
The short version:
A change in how Twill renders blocks necessitates us moving a method out of the our `App\Model\Vendor\Block` override model and into a helper.

The long version:
When using Twill 2, we created [`VendorServiceProvider`](https://github.com/art-institute-of-chicago/artic.edu/blob/develop/app/Providers/VendorServiceProvider.php) to swap our [override Block model](https://github.com/art-institute-of-chicago/artic.edu/blob/develop/app/Models/Vendor/Block.php) for the [Twill Block model](https://github.com/area17/twill/blob/3.x/src/Models/Block.php) during dependency injection. (See https://laravel.com/docs/11.x/container#binding-interfaces-to-implementations for details on how this works.) However, due to [this new line](https://github.com/area17/twill/blob/3.x/src/Helpers/BlockRenderer.php#L89) in Twill 3, nested blocks (including repeaters) are instantiated inline rather than during injection, so they will always be instances of Twill's Block model. In order to allow repeaters to access the `getImgixTileSource` function that was defined in our override model, I moved it into a helper.