### PR TITLE
C&S - Resources

### DIFF
--- a/frontend/scss/pages/types/_t-conservation-and-science.scss
+++ b/frontend/scss/pages/types/_t-conservation-and-science.scss
@@ -126,7 +126,7 @@
     }
   }
 
-  .o-grid-block {
+  .o-grid-block:has(#our-work) {
     @include breakpoint('large+') {
       margin-left: unset !important;
     }
@@ -158,6 +158,24 @@
         color: $color__black--80;
         font-size: 17px;
         line-height: 28px;
+      }
+    }
+  }
+
+  .o-grid-block:has(#resources) {
+    .m-listing__img {
+      display: none;
+    }
+
+    @include breakpoint('xsmall') {
+      .m-listing__meta {
+        min-height: unset;
+      }
+    }
+
+    @include breakpoint('small+') {
+      .m-listing__meta .f-link {
+        margin: auto 0 0;
       }
     }
   }

--- a/resources/views/site/blocks/grid.blade.php
+++ b/resources/views/site/blocks/grid.blade.php
@@ -2,6 +2,17 @@
     $gridTitle = $block->input('heading');
     $gridLinkLabel = $block->input('grid_link_label');
     $gridLinkHref = $block->input('grid_link_href');
+    $variation = $block->input('variation');
+    switch ($variation) {
+        case '4-wide':
+            $width = $widthSmall = '4';
+            break;
+        case '3-wide':
+        default:
+            $width = '3';
+            $widthSmall = '2';
+            break;
+    }
 @endphp
 
 <div class="o-grid-block">
@@ -23,10 +34,10 @@
 
     @component('components.organisms._o-grid-listing')
         @slot('variation', 'o-grid-listing--gridlines-cols o-grid-listing--gridlines-rows')
-        @slot('cols_small','2')
-        @slot('cols_medium','3')
-        @slot('cols_large','3')
-        @slot('cols_xlarge','3')
+        @slot('cols_small', $widthSmall)
+        @slot('cols_medium', $width)
+        @slot('cols_large', $width)
+        @slot('cols_xlarge', $width)
         @foreach ($block->children as $item)
             @component('components.molecules._m-listing----grid-item')
                 @slot('url', $item->input('url'))

--- a/resources/views/twill/blocks/grid.blade.php
+++ b/resources/views/twill/blocks/grid.blade.php
@@ -21,6 +21,22 @@
     :maxlength='60'
 />
 
+<x-twill::select
+    name='variation'
+    label='Variation'
+    default="3-wide"
+    :options="[
+        [
+            'value' => '3-wide',
+            'label' => 'Default (3 wide)',
+        ],
+        [
+            'value' => '4-wide',
+            'label' => '4 wide',
+        ],
+    ]"
+/>
+
 <x-twill::repeater
     type="grid_item"
 />


### PR DESCRIPTION
This change adapts the grid block for the Resources section of the Conservation and Science landing page.