### PR TITLE
Address Sass warning emitted by Webpack

### DIFF
--- a/frontend/scss/pages/types/_t-publications.scss
+++ b/frontend/scss/pages/types/_t-publications.scss
@@ -62,7 +62,7 @@
 
             .m-listing__img {
                 aspect-ratio: 1/1;
-                
+
                 background-color: transparent;
 
                 img {
@@ -91,12 +91,13 @@
             flex-direction: column;
 
             @include breakpoint('medium-') {
+                max-width: 100%;
+                padding-bottom: 20px;
+
                 &:not(:first-child) {
                     border-top: 1px solid $color__black--10;
                     padding-top: 20px;
                 }
-                padding-bottom: 20px;
-                max-width: 100%;
             }
 
             >h3 {


### PR DESCRIPTION
Sass was throwing these warnings about placing direct declarations after nested ones:
```
WARNING in ./frontend/scss/app.scss (./frontend/scss/app.scss.webpack[javascript/auto]!=!./node_modules/css-loader/dist/cjs.js??ruleSet[1].rules[1].use[1]!./node_modules/sass-loader/dist/cjs.js??ruleSet[1].rules[1].use[2]!./frontend/scss/app.scss)
Module Warning (from ./node_modules/sass-loader/dist/cjs.js):
Deprecation Warning on line 97, column 16 of file:///Users/zgarwo/Documents/artic.edu/frontend/scss/pages/types/_t-publications.scss:97:16:
Sass's behavior for declarations that appear after nested
rules will be changing to match the behavior specified by CSS in an upcoming
version. To keep the existing behavior, move the declaration above the nested
rule. To opt into the new behavior, wrap the declaration in `& {}`.

More info: https://sass-lang.com/d/mixed-decls

97 |                 padding-bottom: 20px;


frontend/scss/pages/types/_t-publications.scss 98:17  @content
frontend/scss/setup/mixins/_breakpoint.scss 74:7      breakpoint()
frontend/scss/pages/types/_t-publications.scss 93:13  @import
frontend/scss/pages/_p-landingpage-show.scss 7:9      @import
frontend/scss/_importsCore.scss 149:9                 @import
frontend/scss/app.scss 7:10                           root stylesheet

 @ ./frontend/scss/app.scss

WARNING in ./frontend/scss/app.scss (./frontend/scss/app.scss.webpack[javascript/auto]!=!./node_modules/css-loader/dist/cjs.js??ruleSet[1].rules[1].use[1]!./node_modules/sass-loader/dist/cjs.js??ruleSet[1].rules[1].use[2]!./frontend/scss/app.scss)
Module Warning (from ./node_modules/sass-loader/dist/cjs.js):
Deprecation Warning on line 98, column 16 of file:///Users/zgarwo/Documents/artic.edu/frontend/scss/pages/types/_t-publications.scss:98:16:
Sass's behavior for declarations that appear after nested
rules will be changing to match the behavior specified by CSS in an upcoming
version. To keep the existing behavior, move the declaration above the nested
rule. To opt into the new behavior, wrap the declaration in `& {}`.

More info: https://sass-lang.com/d/mixed-decls

98 |                 max-width: 100%;


frontend/scss/pages/types/_t-publications.scss 99:17  @content
frontend/scss/setup/mixins/_breakpoint.scss 74:7      breakpoint()
frontend/scss/pages/types/_t-publications.scss 93:13  @import
frontend/scss/pages/_p-landingpage-show.scss 7:9      @import
frontend/scss/_importsCore.scss 149:9                 @import
frontend/scss/app.scss 7:10                           root stylesheet

 @ ./frontend/scss/app.scss
```