### PR TITLE
Fix C&S Resources section styling

### DIFF
--- a/frontend/scss/pages/types/_t-conservation-and-science.scss
+++ b/frontend/scss/pages/types/_t-conservation-and-science.scss
@@ -285,15 +285,19 @@
     }
   }
 
-  .o-grid-block:has(#our-work) {
-    @include breakpoint('large+') {
-      margin-left: unset !important;
-    }
+  .o-grid-block {
+    margin-bottom: 100px;
 
     .m-title-bar::before {
       content: none;
     }
 
+    @include breakpoint('large+') {
+      margin-left: unset !important;
+    }
+  }
+
+  .o-grid-block:has(#our-work) {
     .hr {
       @each $name, $point in $breakpoints {
         @include breakpoint('#{$name}') {


### PR DESCRIPTION
This correctly aligns the section on wide screens, as well as removes the top border and adds an appropriate bottom margin.