### PR TITLE
Set link url to distinct field name

### DIFF
--- a/resources/views/components/molecules/_m-media.blade.php
+++ b/resources/views/components/molecules/_m-media.blade.php
@@ -327,8 +327,8 @@
         @if (isset($item['caption']) && $item['caption'])
             <div class="{{ $fitCaptionTitle ? 'f-fit-text' : '' }} f-caption">{!! $item['caption'] !!}</div>
         @endif
-        @if (isset($item['linkLabel']) && $item['linkLabel'] && isset($item['href']) && $item['href'])
-            <a href="{!! $item['href'] !!}">
+        @if (isset($item['linkLabel']) && $item['linkLabel'] && isset($item['linkUrl']) && $item['linkUrl'])
+            <a href="{!! $item['linkUrl'] !!}">
                 <span class="f-link">
                     {!! $item['linkLabel'] !!} <svg class='icon--arrow'><use xlink:href='#icon--arrow'></use></svg>
                 </span>

--- a/resources/views/site/blocks/gallery_new.blade.php
+++ b/resources/views/site/blocks/gallery_new.blade.php
@@ -94,7 +94,7 @@
                     'fullscreen' => $block->input('disable_gallery_modals') ? false : true,
                     'media' => $item->imageAsArray('gallery_item', 'conservation_and_science'),
                     'videoUrl' => $item->input('videoUrl'),
-                    'href' => $item->input('linkUrl'),
+                    'linkUrl' => $item->input('linkUrl'),
                     'linkLabel' => $item->input('linkLabel'),
                 ]);
                 if (($block->input('is_gallery_zoomable') ?? false) || $item->input('is_zoomable')) {


### PR DESCRIPTION
This change undoes me setting the field `linkUrl` to `href` without realizing this would cause a DOM conflict trying to render an `<a>` within an `<a>`.