### PR TITLE
Adapt all calls to config('app.url') to assume the protocol in specified [WEB-2953]

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,10 +3,8 @@ APP_ENV='local'
 APP_KEY=
 APP_DEBUG=true
 APP_LOG_LEVEL='debug'
-APP_URL='www.test'
-APP_PROTOCOL='https'
-HOSTNAME='www.test'
-ADMIN_APP_URL='admin.www.test'
+APP_URL='http://www.test'
+ADMIN_APP_URL='http://admin.www.test'
 ADMIN_APP_STRICT=true
 
 ALLOWED_DOMAINS='www.artic.edu,anothersubdomain.artic.edu'

--- a/.env.testing
+++ b/.env.testing
@@ -2,8 +2,9 @@ APP_NAME='AIC'
 APP_ENV='testing'
 APP_KEY=base64:60wNKBESwQBA2mTuC/FSVKb0mI/qS9Ky6QqO+4EzMx4=
 APP_DEBUG=true
-APP_LOG_LEVEL='debug'
-APP_URL='localhost'
+APP_URL='http://localhost'
+
+LOG_LEVEL='debug'
 
 DB_CONNECTION='pgsql'
 DB_HOST='127.0.0.1'

--- a/app/Console/Commands/GeneratePdfs.php
+++ b/app/Console/Commands/GeneratePdfs.php
@@ -71,7 +71,7 @@ class GeneratePdfs extends Command
         if (empty($route)) {
             return false;
         }
-        $baseUrl = config('aic.protocol') . '://' . config('app.url');
+        $baseUrl = config('app.url');
         $fullUrl = $baseUrl . $this->path($model, $route);
 
         // Now, produce the PDF

--- a/app/Console/Commands/GenerateSitemap.php
+++ b/app/Console/Commands/GenerateSitemap.php
@@ -30,7 +30,7 @@ class GenerateSitemap extends Command
 
     public function handle()
     {
-        $this->prefix = config('sitemap.base_url') ?? ('https://' . config('app.url'));
+        $this->prefix = config('sitemap.base_url') ?? config('app.url');
         $this->prefix = rtrim($this->prefix, '/');
 
         $this->crawlPrefix = config('sitemap.crawl_url') ?? $this->prefix;

--- a/app/Console/Commands/SendConfirmations.php
+++ b/app/Console/Commands/SendConfirmations.php
@@ -79,7 +79,7 @@ class SendConfirmations extends Command
         $senderName = config('sendgrid.name');
         $templateId = config('sendgrid.template_id');
 
-        $baseUrl = config('aic.protocol') . '://' . config('app.url');
+        $baseUrl = config('app.url');
         $tourUrl = $baseUrl . route('my-museum-tour.show', [ 'id' => $model->id ], false);
 
         $dynamicContent = [

--- a/app/Http/Controllers/CollectionController.php
+++ b/app/Http/Controllers/CollectionController.php
@@ -83,7 +83,7 @@ class CollectionController extends BaseScopedController
             $this->seo->setImage($artwork->imageFront('hero'));
         } else {
             // Otherwise, fall back to La Grande Jatte as social image
-            $this->seo->image = 'https://' . rtrim(config('app.url'), '/') . '/iiif/2/4eddcf49-3efd-d993-fb1a-75d7e7d5b5a1/full/843,/0/default.jpg';
+            $this->seo->image = rtrim(config('app.url'), '/') . '/iiif/2/4eddcf49-3efd-d993-fb1a-75d7e7d5b5a1/full/843,/0/default.jpg';
             $this->seo->width = 1200;
             $this->seo->height = 799;
         }

--- a/app/Http/Controllers/MyMuseumTourController.php
+++ b/app/Http/Controllers/MyMuseumTourController.php
@@ -105,7 +105,7 @@ class MyMuseumTourController extends FrontController
     {
         $myMuseumTour = MyMuseumTour::findOrFail($id);
 
-        $baseUrl = config('aic.protocol') . '://' . config('app.url');
+        $baseUrl = config('app.url');
         $fullUrl = $baseUrl . route('my-museum-tour.show', [ 'id' => $myMuseumTour->id ], false);
 
         $options = new QROptions(

--- a/app/Http/Controllers/RobotsController.php
+++ b/app/Http/Controllers/RobotsController.php
@@ -8,7 +8,7 @@ class RobotsController extends FrontController
 {
     public function index(Request $request)
     {
-        if (config('app.env') === 'production' && config('app.url') === $request->getHttpHost()) {
+        if (config('app.env') === 'production' && config('app.url') === $request->getSchemeAndHttpHost()) {
             return response()
                 ->view('site.robots')
                 ->header('Content-Type', 'text/plain');

--- a/app/Http/Controllers/Twill/ArticleController.php
+++ b/app/Http/Controllers/Twill/ArticleController.php
@@ -40,7 +40,7 @@ class ArticleController extends BaseController
     protected function formData($request)
     {
         $item = $this->repository->getById(request('article') ?? request('id'));
-        $baseUrl = '//' . config('app.url') . '/articles/' . $item->id . '/';
+        $baseUrl = config('app.url') . '/articles/' . $item->id . '/';
 
         return [
             'autoRelated' => $this->getAutoRelated($item),

--- a/app/Http/Controllers/Twill/ArtistController.php
+++ b/app/Http/Controllers/Twill/ArtistController.php
@@ -15,7 +15,7 @@ class ArtistController extends BaseApiController
     protected function formData($request)
     {
         $item = $this->repository->getById(request('artist') ?? request('id'));
-        $baseUrl = '//' . config('app.url') . '/artists/' . $item->datahub_id . '/';
+        $baseUrl = config('app.url') . '/artists/' . $item->datahub_id . '/';
 
         return [
             'baseUrl' => $baseUrl,

--- a/app/Http/Controllers/Twill/ArtworkController.php
+++ b/app/Http/Controllers/Twill/ArtworkController.php
@@ -39,7 +39,7 @@ class ArtworkController extends BaseApiController
     protected function formData($request)
     {
         $item = $this->repository->getById(request('artwork') ?? request('id'));
-        $baseUrl = '//' . config('app.url') . '/artworks/' . $item->datahub_id . '/';
+        $baseUrl = config('app.url') . '/artworks/' . $item->datahub_id . '/';
 
         return [
             'autoRelated' => $this->getAutoRelated($item),

--- a/app/Http/Controllers/Twill/AuthorController.php
+++ b/app/Http/Controllers/Twill/AuthorController.php
@@ -12,7 +12,7 @@ class AuthorController extends BaseController
     protected function formData($request)
     {
         $item = $this->repository->getById(request('author') ?? request('id'));
-        $baseUrl = '//' . config('app.url') . '/authors/' . $item->id . '/';
+        $baseUrl = config('app.url') . '/authors/' . $item->id . '/';
 
         return [
             'baseUrl' => $baseUrl,

--- a/app/Http/Controllers/Twill/DepartmentController.php
+++ b/app/Http/Controllers/Twill/DepartmentController.php
@@ -14,7 +14,7 @@ class DepartmentController extends BaseApiController
     protected function formData($request)
     {
         $item = $this->repository->getById(request('department') ?? request('id'));
-        $baseUrl = '//' . config('app.url') . '/departments/' . $item->datahub_id . '/';
+        $baseUrl = config('app.url') . '/departments/' . $item->datahub_id . '/';
 
         return [
             'baseUrl' => $baseUrl,

--- a/app/Http/Controllers/Twill/DigitalPublicationArticleController.php
+++ b/app/Http/Controllers/Twill/DigitalPublicationArticleController.php
@@ -130,7 +130,7 @@ class DigitalPublicationArticleController extends NestedModuleController
     {
         $item = $this->repository->getById(request('article') ?? request('id'));
         $digPub = app(DigitalPublicationRepository::class)->getById(request('digitalPublication'));
-        $baseUrl = '//' . config('app.url') . '/' . $this->permalinkBase . $digPub->id . '/' . $digPub->getSlug() . '/' . $item->id . '/';
+        $baseUrl = config('app.url') . '/' . $this->permalinkBase . $digPub->id . '/' . $digPub->getSlug() . '/' . $item->id . '/';
 
         return [
             'types' => $this->repository->getTypes(),

--- a/app/Http/Controllers/Twill/DigitalPublicationController.php
+++ b/app/Http/Controllers/Twill/DigitalPublicationController.php
@@ -36,7 +36,7 @@ class DigitalPublicationController extends BaseController
     protected function formData($request)
     {
         $item = $this->repository->getById(request('digitalPublication') ?? request('id'));
-        $baseUrl = '//' . config('app.url') . '/digital-publications/' . $item->id . '/';
+        $baseUrl = config('app.url') . '/digital-publications/' . $item->id . '/';
         $heroBackgroundColors = collect(config('aic.branding.digital_publications.colors'))
             ->mapWithKeys(fn ($hexColor) => [$hexColor => $hexColor]);
 

--- a/app/Http/Controllers/Twill/EducatorResourceController.php
+++ b/app/Http/Controllers/Twill/EducatorResourceController.php
@@ -14,7 +14,7 @@ class EducatorResourceController extends BaseController
 
     protected function formData($request)
     {
-        $baseUrl = '//' . config('app.url') . '/collection/resources/educator-resources/';
+        $baseUrl = config('app.url') . '/collection/resources/educator-resources/';
 
         return [
             'categoriesList' => app(ResourceCategoryRepository::class)->listAll('name'),

--- a/app/Http/Controllers/Twill/EventController.php
+++ b/app/Http/Controllers/Twill/EventController.php
@@ -95,7 +95,7 @@ class EventController extends BaseController
     protected function formData($request)
     {
         $item = $this->repository->getById(request('event') ?? request('id'));
-        $baseUrl = '//' . config('app.url') . '/events/' . $item->id . '/';
+        $baseUrl = config('app.url') . '/events/' . $item->id . '/';
 
         return [
             'autoRelated' => $this->getAutoRelated($item),

--- a/app/Http/Controllers/Twill/ExhibitionController.php
+++ b/app/Http/Controllers/Twill/ExhibitionController.php
@@ -40,7 +40,7 @@ class ExhibitionController extends BaseApiController
     protected function formData($request)
     {
         $item = $this->repository->getById(request('exhibition') ?? request('id'));
-        $baseUrl = '//' . config('app.url') . '/exhibitions/' . $item->datahub_id . '/';
+        $baseUrl = config('app.url') . '/exhibitions/' . $item->datahub_id . '/';
 
         return [
             'autoRelated' => $this->getAutoRelated($item),

--- a/app/Http/Controllers/Twill/ExhibitionPressRoomController.php
+++ b/app/Http/Controllers/Twill/ExhibitionPressRoomController.php
@@ -12,7 +12,7 @@ class ExhibitionPressRoomController extends BaseController
 
     protected function formData($request)
     {
-        $baseUrl = '//' . config('app.url') . '/press/exhibition-press-room' . '/' . request('exhibitionPressRoom') . '/';
+        $baseUrl = config('app.url') . '/press/exhibition-press-room' . '/' . request('exhibitionPressRoom') . '/';
 
         return [
             'baseUrl' => $baseUrl,

--- a/app/Http/Controllers/Twill/ExperienceController.php
+++ b/app/Http/Controllers/Twill/ExperienceController.php
@@ -62,7 +62,7 @@ class ExperienceController extends BaseController
 
     public function getPermalinkBaseUrl()
     {
-        return request()->getScheme() . '://' . config('app.url') . '/interactive-features/';
+        return config('app.url') . '/interactive-features/';
     }
 
     protected function previewData($item)

--- a/app/Http/Controllers/Twill/GalleryController.php
+++ b/app/Http/Controllers/Twill/GalleryController.php
@@ -14,7 +14,7 @@ class GalleryController extends BaseApiController
     protected function formData($request)
     {
         $item = $this->repository->getById(request('gallery') ?? request('id'));
-        $baseUrl = '//' . config('app.url') . '/galleries/' . $item->datahub_id . '/';
+        $baseUrl = config('app.url') . '/galleries/' . $item->datahub_id . '/';
 
         return [
             'baseUrl' => $baseUrl,

--- a/app/Http/Controllers/Twill/GenericPageController.php
+++ b/app/Http/Controllers/Twill/GenericPageController.php
@@ -43,7 +43,7 @@ class GenericPageController extends BaseController
         $item = $this->repository->getById(request('genericPage') ?? request('id'));
         $ancestors = $item->ancestors()->defaultOrder()->get();
 
-        $baseUrl = '//' . config('app.url') . '/';
+        $baseUrl = config('app.url') . '/';
 
         foreach ($ancestors as $ancestor) {
             $baseUrl = $baseUrl . $ancestor->slug . '/';

--- a/app/Http/Controllers/Twill/HighlightController.php
+++ b/app/Http/Controllers/Twill/HighlightController.php
@@ -32,7 +32,7 @@ class HighlightController extends BaseController
     protected function formData($request)
     {
         $item = $this->repository->getById(request('highlight') ?? request('id'));
-        $baseUrl = '//' . config('app.url') . '/highlights/' . request('highlight') . '/';
+        $baseUrl = config('app.url') . '/highlights/' . request('highlight') . '/';
 
         return [
             'autoRelated' => $this->getAutoRelated($item),

--- a/app/Http/Controllers/Twill/LandingPageController.php
+++ b/app/Http/Controllers/Twill/LandingPageController.php
@@ -52,7 +52,7 @@ class LandingPageController extends BaseController
     protected function formData($request)
     {
         $types = collect(LandingPage::TYPES);
-        $baseUrl = '//' . config('app.url') . '/';
+        $baseUrl = config('app.url') . '/';
 
         return [
             'defaultType' => $types->search(LandingPage::DEFAULT_TYPE),

--- a/app/Http/Controllers/Twill/MagazineIssueController.php
+++ b/app/Http/Controllers/Twill/MagazineIssueController.php
@@ -18,7 +18,7 @@ class MagazineIssueController extends BaseController
     protected function formData($request)
     {
         $item = $this->repository->getById(request('magazineIssue') ?? request('id'));
-        $baseUrl = '//' . config('app.url') . '/' . $this->permalinkBase . $item->id . '/';
+        $baseUrl = config('app.url') . '/' . $this->permalinkBase . $item->id . '/';
 
         return [
             'baseUrl' => $baseUrl,

--- a/app/Http/Controllers/Twill/MiradorController.php
+++ b/app/Http/Controllers/Twill/MiradorController.php
@@ -13,7 +13,7 @@ class MiradorController extends BaseController
     protected function formData($request)
     {
         $item = $this->repository->getById(request('mirador') ?? request('id'));
-        $baseUrl = '//' . config('app.url') . '/mirador/' . $item->id . '/';
+        $baseUrl = config('app.url') . '/mirador/' . $item->id . '/';
 
         return [
             'baseUrl' => $baseUrl,

--- a/app/Http/Controllers/Twill/PressReleaseController.php
+++ b/app/Http/Controllers/Twill/PressReleaseController.php
@@ -29,7 +29,7 @@ class PressReleaseController extends BaseController
 
     protected function formData($request)
     {
-        $baseUrl = '//' . config('app.url') . '/press/press-releases/' . request('pressRelease') . '/';
+        $baseUrl = config('app.url') . '/press/press-releases/' . request('pressRelease') . '/';
 
         return [
             'baseUrl' => $baseUrl,

--- a/app/Http/Controllers/Twill/PrintedPublicationController.php
+++ b/app/Http/Controllers/Twill/PrintedPublicationController.php
@@ -14,7 +14,7 @@ class PrintedPublicationController extends BaseController
 
     protected function formData($request)
     {
-        $baseUrl = '//' . config('app.url') . '/print-publications/';
+        $baseUrl = config('app.url') . '/print-publications/';
 
         return [
             'categoriesList' => app(CatalogCategoryRepository::class)->listAll('name'),

--- a/app/Http/Controllers/Twill/VideoController.php
+++ b/app/Http/Controllers/Twill/VideoController.php
@@ -15,7 +15,7 @@ class VideoController extends BaseController
     protected function formData($request)
     {
         $item = $this->repository->getById(request('video') ?? request('id'));
-        $baseUrl = '//' . config('app.url') . '/videos/' . $item->id . '-';
+        $baseUrl = config('app.url') . '/videos/' . $item->id . '-';
 
         return [
             'baseUrl' => $baseUrl,

--- a/app/Models/AbstractModel.php
+++ b/app/Models/AbstractModel.php
@@ -59,9 +59,8 @@ class AbstractModel extends Model
 
     public function getPreviewUrl($baseUrl)
     {
-        // $baseUrl is missing protocol, starts with //, and ends with /
-        // config('app.url') should have no https://
-        return '//' . config('app.url') . '/p/' . encrypt($baseUrl . $this->slug);
+        // $baseUrl ends with /
+        return config('app.url') . '/p/' . encrypt($baseUrl . $this->slug);
     }
 
     public function shouldGenerateSlugsOnSave()

--- a/app/Models/Api/Asset.php
+++ b/app/Models/Api/Asset.php
@@ -91,7 +91,7 @@ class Asset extends BaseApiModel
     {
         switch ($this->api_model) {
             case 'videos':
-                return '//' . config('app.url') . '/videos/' . $this->id;
+                return config('app.url') . '/videos/' . $this->id;
             case 'articles':
             case 'sites':
                 return $this->web_url;

--- a/app/Models/Event.php
+++ b/app/Models/Event.php
@@ -424,7 +424,7 @@ class Event extends AbstractModel
     public function getProgramUrlsAttribute()
     {
         return $this->programs->reduce(function ($carry, $item) {
-            return $carry . 'https://' . config('app.url') . route('events', [], false) . '?program=' . $item->id . "\n";
+            return $carry . config('app.url') . route('events', [], false) . '?program=' . $item->id . "\n";
         });
     }
 

--- a/resources/views/partials/metas/_url.blade.php
+++ b/resources/views/partials/metas/_url.blade.php
@@ -1,5 +1,5 @@
 @php
-    $app_url  = 'https://' .rtrim(config('app.url'), '/') . '/';
+    $app_url  = rtrim(config('app.url'), '/') . '/';
     $url      = $canonicalUrl ?? ($app_url . trim(Request::path(), '/'));
 
     $robots = array_filter([

--- a/resources/views/site/myMuseumTour.blade.php
+++ b/resources/views/site/myMuseumTour.blade.php
@@ -112,7 +112,7 @@
                                         "restrict" => false,
                                     ];
                                 @endphp
-                                <a href="{{ config('aic.protocol') }}://{{ rtrim(config('app.url')) }}/artworks/{{ $artwork['id'] }}"
+                                <a href="{{ rtrim(config('app.url')) }}/artworks/{{ $artwork['id'] }}"
                                    aria-label="View full artwork page for {{ $artwork['title'] }}{{ isset($artwork['thumbnail']['alt_text']) ? ': ' . $artwork['thumbnail']['alt_text'] : '' }}">
                                     @component('components.atoms._img')
                                         @slot('image', $artwork_image)
@@ -160,7 +160,7 @@
                                 "{{ $artwork['objectNote'] }}"
                             @endcomponent
                         @endisset
-                        <a href="{{ config('aic.protocol') }}://{{ rtrim(config('app.url')) }}/artworks/{{ $artwork['id'] }}"
+                        <a href="{{ rtrim(config('app.url')) }}/artworks/{{ $artwork['id'] }}"
                            target="_blank"
                            class="external-link f-link"
                            aria-hidden="true">

--- a/tests/Feature/CollectionLandingTest.php
+++ b/tests/Feature/CollectionLandingTest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Tests\Feature;
+
+use Aic\Hub\Foundation\Testing\FeatureTestCase as BaseTestCase;
+use App\Models\Page;
+use App\Models\Event;
+use Aic\Hub\Foundation\Testing\MockApi;
+
+class CollectionLandingTest extends BaseTestCase
+{
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        Page::firstOrCreate(['type' => 2], [
+            'position' => 2,
+            'published' => 1,
+            'title' => 'Art & Artists'
+        ]);
+    }
+
+    public function test_collection_landing_loads(): void
+    {
+        $response = $this->get(route('collection'));
+        $response->assertStatus(200);
+    }
+
+    /**
+     * A search with no results falls back to a predefined SEO image. This test verifies that the
+     * fallback image is rendered as a <meta itemprop="image"> tag with a fully qualified URL using
+     * the config's APP_URL.
+     */
+    public function test_collection_landing_seo_image(): void
+    {
+        $response = $this->get(route('collection', ['q' => 'sdflisdfkuhsdfkughsdfkughsfd']));
+        $html = preg_replace('/\s+/', ' ', $response->getContent());
+        $this->assertStringContainsString('<meta itemprop="image" content="http', $html);
+        $this->assertStringContainsString('<meta itemprop="image" content="' . config('app.url'), $html);
+    }
+}

--- a/tests/Feature/RobotsTxtTest.php
+++ b/tests/Feature/RobotsTxtTest.php
@@ -24,7 +24,7 @@ class RobotsTxtTest extends BaseTestCase
     {
         Config::set('app.env', 'production');
         Config::set('app.debug', false);
-        Config::set('app.url', 'www.example.com');
+        Config::set('app.url', 'http://www.example.com');
         $response = $this->get(route('robots-txt'));
         $this->assertEquals("User-agent: *\nDisallow: /", $response->getContent());
     }


### PR DESCRIPTION
This was originally part of the Laravel 11 PR, but the Twill 3 upgrade has surfaced an issue that this commit resolves.

Right now we only list the domain in the APP_URL value. This PR assumes we have a full qualified URL in the value for APP_URL, so we remove some extra cruft around the usage of that value to assume so. To test this PR you'll need to update the APP_URL in your .env to include `http://`.