### PR TITLE
Adjust aspect ratio for 1-and-2 editorial variation [WEB-3071]

### DIFF
--- a/frontend/scss/molecules/_m-editorial-block.scss
+++ b/frontend/scss/molecules/_m-editorial-block.scss
@@ -847,7 +847,6 @@
                 }
 
                 .m-listing__img {
-                    aspect-ratio: 1;
                     max-height: fit-content;
                 }
 

--- a/frontend/scss/pages/types/_t-research-center.scss
+++ b/frontend/scss/pages/types/_t-research-center.scss
@@ -355,6 +355,11 @@
         .title {
           font-size: 22px;
           line-height: 28px;
+          margin-top: 0;
+
+          &::before {
+            display: none;
+          }
         }
 
         .intro {


### PR DESCRIPTION
This removes the forced 1/1 aspect ratio for images in the `1-and-2` variation on the Editorial block. Also, I removed extraneous space above the titles.