### PR TITLE
Remove padding adjustments from custom/tag banners [WEB-3070]

### DIFF
--- a/frontend/scss/molecules/_m-custom-banner.scss
+++ b/frontend/scss/molecules/_m-custom-banner.scss
@@ -70,14 +70,12 @@
             flex-direction: column;
             justify-content: space-around;
             align-items: flex-start;
-            padding: 50px;
         }
 
         @include breakpoint('small') {
             flex-direction: column;
             justify-content: space-around;
             align-items: flex-start;
-            padding: 50px;
         }
 
         @include breakpoint('xsmall') {

--- a/frontend/scss/pages/types/_t-research-center.scss
+++ b/frontend/scss/pages/types/_t-research-center.scss
@@ -79,8 +79,6 @@
     }
 
     .body-wrapper {
-      padding: 30px;
-
       @include breakpoint('xsmall') {
         padding: 15px;
       }


### PR DESCRIPTION
The default padding on the banners is 56px -- the desired amount -- so I removed the padding adjustments from the Tag Banner and Custom Banner blocks' stylings.