### PR TITLE
Fix split block style on mobile [PUB-319]

### DIFF
--- a/frontend/scss/molecules/_m-split-block.scss
+++ b/frontend/scss/molecules/_m-split-block.scss
@@ -1,7 +1,7 @@
 .m-split-block {
 
   display: flex;
-  flex-flow: row wrap;
+  flex-flow: row;
   margin-top: 28px;
 
   @include breakpoint('small+') {
@@ -38,6 +38,11 @@
     }
   }
 
+}
+
+.m-split-block .o-blocks>h4:not([class*='f-']) {
+  margin-bottom: unset;
+  margin-top: unset;
 }
 
 // Removes baseline adjustments


### PR DESCRIPTION
- Address unnecessary wrapping to new line
- Fix text lines getting "squooshed" together