### PR TITLE
Remove BuildingClosure type [WEB-3121]

### DIFF
--- a/app/Http/Controllers/Twill/BuildingClosureController.php
+++ b/app/Http/Controllers/Twill/BuildingClosureController.php
@@ -3,11 +3,8 @@
 namespace App\Http\Controllers\Twill;
 
 use A17\Twill\Services\Listings\Columns\Text;
-use A17\Twill\Services\Listings\Filters\BasicFilter;
-use A17\Twill\Services\Listings\Filters\TableFilters;
 use A17\Twill\Services\Listings\TableColumns;
 use App\Models\BuildingClosure;
-use Illuminate\Database\Eloquent\Builder;
 
 class BuildingClosureController extends BaseController
 {
@@ -15,24 +12,16 @@ class BuildingClosureController extends BaseController
     {
         $this->setModuleName('buildingClosures');
         $this->setSearchColumns(['closure_copy']);
-        $this->setTitleColumnKey('presentType');
-        $this->setTitleColumnLabel('Type');
-        $this->setTitleFormKey('cmsFormTitle');
+        $this->setTitleColumnLabel('Closure');
+        $this->setTitleFormKey('title');
     }
 
-    public function filters(): TableFilters
+    public function getIndexTableColumns(): TableColumns
     {
-        $tableFilters = parent::filters();
-        $tableFilters->add(
-            BasicFilter::make()
-                ->queryString('types')
-                ->options(collect(BuildingClosure::$types))
-                ->apply(function (Builder $builder, mixed $value) {
-                    $builder->where('type', '=', $value);
-                })
-        );
-
-        return $tableFilters;
+        $columns = parent::getIndexTableColumns();
+        $titleColumn = $columns->slice(1, 1)->first();
+        $titleColumn->sortKey('date_start');
+        return $columns;
     }
 
     public function additionalIndexTableColumns(): TableColumns
@@ -70,20 +59,5 @@ class BuildingClosureController extends BaseController
         );
 
         return $columns;
-    }
-
-    protected function indexData($request)
-    {
-        return [
-            'typesList' => collect(BuildingClosure::$types),
-        ];
-    }
-
-    protected function formData($request)
-    {
-        return [
-            'typesList' => collect(BuildingClosure::$types),
-            'editableTitle' => false,
-        ];
     }
 }

--- a/app/Http/Requests/Twill/BuildingClosureRequest.php
+++ b/app/Http/Requests/Twill/BuildingClosureRequest.php
@@ -8,7 +8,7 @@ class BuildingClosureRequest extends Request
 {
     public function rules(): array
     {
-        $rules = ['type' => 'required'];
+        $rules = [];
 
         if (!empty($this->input('date_end'))) {
             $rules['date_start'] = 'required|before_or_equal:date_end';

--- a/app/Models/BuildingClosure.php
+++ b/app/Models/BuildingClosure.php
@@ -41,7 +41,7 @@ class BuildingClosure extends AbstractModel
         'title',
     ];
 
-    public function scopetoday($query): Builder
+    public function scopeToday($query): Builder
     {
         $today = Carbon::today();
 

--- a/app/Models/BuildingClosure.php
+++ b/app/Models/BuildingClosure.php
@@ -19,17 +19,8 @@ class BuildingClosure extends AbstractModel
         'date_start',
         'date_end',
         'closure_copy',
-        'type',
         'hour_id'
     ];
-
-    public static $types = [
-        0 => 'Museum',
-        1 => 'Shop',
-        2 => 'Library',
-    ];
-
-    public $nullable = [];
 
     public $casts = [
         'published' => 'boolean',
@@ -47,22 +38,21 @@ class BuildingClosure extends AbstractModel
     ];
 
     protected $appends = [
-        'presentType',
+        'title',
     ];
 
-    public function scopeToday($query, $type = 0): Builder
+    public function scopetoday($query): Builder
     {
         $today = Carbon::today();
 
         return $query->published()
-            ->where('type', $type)
             ->where('date_start', '<=', $today)
             ->where('date_end', '>=', $today);
     }
 
-    public function getPresentTypeAttribute()
+    public function getTitleAttribute()
     {
-        return self::$types[$this->type];
+        return (new Carbon($this->attributes['date_start']))->diffForHumans();
     }
 
     protected function transformMappingInternal()
@@ -98,14 +88,6 @@ class BuildingClosure extends AbstractModel
                 'type' => 'text',
                 'value' => function () {
                     return $this->closure_copy;
-                },
-            ],
-            [
-                'name' => 'type',
-                'doc' => 'Type of Closure',
-                'type' => 'number',
-                'value' => function () {
-                    return $this->type;
                 },
             ],
         ];

--- a/app/Presenters/BuildingClosurePresenter.php
+++ b/app/Presenters/BuildingClosurePresenter.php
@@ -2,8 +2,6 @@
 
 namespace App\Presenters;
 
-use App\Models\BuildingClosure;
-
 class BuildingClosurePresenter extends BasePresenter
 {
     public function presentStartDate()
@@ -18,11 +16,6 @@ class BuildingClosurePresenter extends BasePresenter
         if ($this->entity->date_end) {
             return $this->entity->date_end->format('M j, Y');
         }
-    }
-
-    public function presentType()
-    {
-        return BuildingClosure::$types[$this->entity->type];
     }
 
     public function closureCopy()

--- a/database/factories/BuildingClosureFactory.php
+++ b/database/factories/BuildingClosureFactory.php
@@ -21,7 +21,6 @@ class BuildingClosureFactory extends Factory
     {
         return [
             'published' => true,
-            'type' => 0,
             'date_start' => today(),
             'date_end' => today(),
             'closure_copy' => 'The museum is closed',

--- a/database/migrations/2025_05_27_151726_drop_type_column_from_building_closures_table.php
+++ b/database/migrations/2025_05_27_151726_drop_type_column_from_building_closures_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('building_closures', function (Blueprint $table) {
+            $table->dropColumn('type');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('building_closures', function (Blueprint $table) {
+            $table->integer('type')->default(0);
+        });
+    }
+};

--- a/database/seeders/HoursTableSeeder.php
+++ b/database/seeders/HoursTableSeeder.php
@@ -11,7 +11,6 @@ class HoursTableSeeder extends Seeder
     {
         $hours = new \App\Models\Hour();
         $hours->valid_from = Carbon::yesterday();
-        $hours->type = 0;
         $hours->title = 'Hours';
         $hours->url = '/visit';
         $hours->monday_is_closed = false;

--- a/database/seeders/HoursTableSeeder.php
+++ b/database/seeders/HoursTableSeeder.php
@@ -11,6 +11,7 @@ class HoursTableSeeder extends Seeder
     {
         $hours = new \App\Models\Hour();
         $hours->valid_from = Carbon::yesterday();
+        $hours->type = 0;
         $hours->title = 'Hours';
         $hours->url = '/visit';
         $hours->monday_is_closed = false;

--- a/resources/views/twill/buildingClosures/create.blade.php
+++ b/resources/views/twill/buildingClosures/create.blade.php
@@ -1,12 +1,4 @@
 @if(!isset($item))
-    <x-twill::select
-        name='"type"'
-        label='"Type"'
-        placeholder='Select a type'
-        :options='$typesList'
-        :required='true'
-    />
-
     <x-twill::date-picker
         name='date_start'
         label='Start date'

--- a/resources/views/twill/buildingClosures/form.blade.php
+++ b/resources/views/twill/buildingClosures/form.blade.php
@@ -1,14 +1,6 @@
 @extends('twill::layouts.form', ['contentFieldsetLabel' => 'Edit closure'])
 
 @section('contentFields')
-    <x-twill::select
-        name='type'
-        label='Type'
-        placeholder='Select a type'
-        :required='true'
-        :options='$typesList'
-    />
-
     <x-twill::date-picker
         name='date_start'
         label='Start Date'
@@ -34,7 +26,7 @@
 
 @push('vuexStore')
     window['{{ config('twill.js_namespace') }}'].STORE.form.fields.push({
-        name: 'cmsFormTitle',
-        value: '{{ $item->presentAdmin()->presentType }} closure'
+        name: 'title',
+        value: '{{ $item->title }} closure'
     })
 @endpush

--- a/tests/Unit/HourTest.php
+++ b/tests/Unit/HourTest.php
@@ -54,7 +54,6 @@ class HourTest extends BaseTestCase
             'date_start' => Carbon::now()->next('Thursday'),
             'date_end' => Carbon::now()->next('Thursday'),
             'closure_copy' => 'The museum is closed on Thursday',
-            'type' => 0,
         ]));
 
         $this->hourAllClosed = Hour::factory()->make([


### PR DESCRIPTION
The BuildingClosure `type` was causing issues with the forms:
![Screenshot 2025-05-27 at 2 48 14 PM](https://github.com/user-attachments/assets/1b0ed2c5-00bc-4e5a-83ef-868913987160)

In the `building_closures.type` column the only value, going back 7 years in the prod db, is `0`, so I removed the column. In the CMS index table, I replaced it with a "Closure" column:

![Screenshot 2025-05-27 at 4 46 47 PM](https://github.com/user-attachments/assets/97ba9f38-2a4c-4a88-b495-bc3d2c3ce8ac)
