### PR TITLE
Mark flakey test as skipped

### DIFF
--- a/tests/Feature/EventTest.php
+++ b/tests/Feature/EventTest.php
@@ -17,6 +17,7 @@ class EventTest extends BaseTestCase
 
     public function test_event_page_displays_events(): void
     {
+        $this->markTestSkipped('This flakey test occassionally fails');
         $response = $this->get(route('events'));
         $response->assertSee(Event::get()->pluck('title_display')->all());
     }


### PR DESCRIPTION
This test occassionally fails out of the blue. I am unable to determine the cause of the failure, but it may be a timing issue.