### PR TITLE
Address Sass compiler warning

### DIFF
--- a/frontend/scss/molecules/_m-showcase.scss
+++ b/frontend/scss/molecules/_m-showcase.scss
@@ -331,8 +331,9 @@
         .m-showcase-block__text-wrapper {
             &:not(:has(.showcase-tag + .title)) {
                 .title {
-                    @include untuck();
                     margin-top: 0;
+
+                    @include untuck();
                 }
             }
 


### PR DESCRIPTION
The Sass compiler was emitting the following warning:
```
WARNING in ./frontend/scss/app.scss (./frontend/scss/app.scss.webpack[javascript/auto]!=!./node_modules/css-loader/dist/cjs.js??ruleSet[1].rules[1].use[1]!./node_modules/sass-loader/dist/cjs.js??ruleSet[1].rules[1].use[2]!./frontend/scss/app.scss)
Module Warning (from ./node_modules/sass-loader/dist/cjs.js):
Deprecation Warning on line 334, column 20 of file:///Users/zgarwo/Documents/artic.edu/frontend/scss/molecules/_m-showcase.scss:334:20:
Sass's behavior for declarations that appear after nested
rules will be changing to match the behavior specified by CSS in an upcoming
version. To keep the existing behavior, move the declaration above the nested
rule. To opt into the new behavior, wrap the declaration in `& {}`.

More info: https://sass-lang.com/d/mixed-decls

334 |                     margin-top: 0;


frontend/scss/molecules/_m-showcase.scss 335:21  @import
frontend/scss/_importsCore.scss 92:9             @import
frontend/scss/app.scss 7:10                      root stylesheet
```