### PR TITLE
Fix restrict image downloads [WEB-3117]

### DIFF
--- a/config/twill/models.php
+++ b/config/twill/models.php
@@ -1,0 +1,5 @@
+<?php
+
+return [
+    'block' => App\Models\Vendor\Block::class,
+];


### PR DESCRIPTION
This change fixes the ability to use the `restrictDownload` behavior for images attached to Blocks that are children of other Blocks. Child blocks are retrieved here:
https://github.com/area17/twill/blob/3.x/src/Models/Block.php#L56

Since we override Twill's Block, we can define our own in the `twill.model.block` configuration, so that ours is instantiated instead.