### PR TITLE
Fix retrieving augmented models for CMS index tables [WEB-3117]

### DIFF
--- a/app/Http/Controllers/Twill/BaseApiController.php
+++ b/app/Http/Controllers/Twill/BaseApiController.php
@@ -242,9 +242,9 @@ class BaseApiController extends ModuleController
             ->title($title);
         if ($this->getIndexOption('edit')) {
             $titleColumn->linkCell(function (TwillModelContract $model) {
-                if ($model->is_augmented) {
+                if ($augmentedModel = $model->getAugmentedModel()) {
                     $action = 'edit';
-                    $id = $model->getAugmentedModel()->id;
+                    $id = $augmentedModel->id;
                 } else {
                     $action = 'augment';
                     $id = $model->id;


### PR DESCRIPTION
There was an issue with the index tables of API models erroring out. This fix properly retrieves the augmented models for API models so the index table can be displayed.