### PR TITLE
Restyle Showcase block heading [WEB-3069]

### DIFF
--- a/frontend/scss/pages/types/_t-conservation-and-science.scss
+++ b/frontend/scss/pages/types/_t-conservation-and-science.scss
@@ -38,6 +38,7 @@
 
     .m-showcase-wrapper {
       flex-direction: row-reverse;
+      gap: 18px 38px;
     }
 
     .m-showcase-block__text-wrapper {
@@ -45,7 +46,11 @@
     }
 
     .showcase-header {
-      display: none;
+      color: $color__black--54;
+      font-family: $sans-serif-font--loaded;
+      font-size: 13px;
+      line-height: 16px;
+      text-transform: uppercase;
     }
 
     .showcase-description {


### PR DESCRIPTION
With the changes to the Showcase block Heading / Tag, the About Us section heading needed to be restyled:
<img width="3680" height="2382" alt="Screenshot 2025-07-11 at 4 24 54 PM" src="https://github.com/user-attachments/assets/456c2174-db6b-4ce1-83d7-2cae2129147e" />
