### PR TITLE
Make Visit landing page FAQs span screen width

### DIFF
--- a/frontend/scss/pages/types/_t-visit.scss
+++ b/frontend/scss/pages/types/_t-visit.scss
@@ -636,7 +636,6 @@
 
   .o-accordion {
     margin-top: 36px;
-    max-width: 1000px;
   }
 
   .faqs-heading {


### PR DESCRIPTION
Alexis said that the FAQs should be full width.