### PR TITLE
Prevent guessing of slug encoding [ART-81]

### DIFF
--- a/app/Helpers/StringHelpers.php
+++ b/app/Helpers/StringHelpers.php
@@ -10,19 +10,20 @@ class StringHelpers
      */
     public static function getUtf8Slug($str, $options = [])
     {
-        // Make sure string is in UTF-8 and strip invalid UTF-8 characters
-        $str = mb_convert_encoding((string) $str, 'UTF-8', mb_list_encodings());
-
         $defaults = [
             'delimiter' => '-',
             'limit' => null,
             'lowercase' => true,
             'replacements' => [],
             'transliterate' => true,
+            'from_encoding' => null,
         ];
 
         // Merge options
         $options = array_merge($defaults, $options);
+
+        // Make sure string is in UTF-8 and strip invalid UTF-8 characters
+        $str = mb_convert_encoding((string) $str, 'UTF-8', $options['from_encoding']);
 
         $char_map = [
             // Latin


### PR DESCRIPTION
The short description is that `getUft8Slug()` was guessing the wrong encoding and erroneously transcoding the given string.

For the long description, see this Twill PR: https://github.com/area17/twill/pull/2771.