### PR TITLE
Fix mobile share & print icons [WEB-3148]

### DIFF
--- a/frontend/scss/organisms/_o-article__primary-actions.scss
+++ b/frontend/scss/organisms/_o-article__primary-actions.scss
@@ -112,6 +112,12 @@
   .o-article__primary-actions {
     padding-top: 0;
 
+    @include breakpoint('small-') {
+      &~.o-article__secondary-actions {
+        display: none;
+      }
+    }
+
     @include breakpoint('medium-') {
       @include background-fill;
 

--- a/resources/views/components/molecules/_m-article-actions.blade.php
+++ b/resources/views/components/molecules/_m-article-actions.blade.php
@@ -41,7 +41,7 @@
     @endif
     @if (empty($hidePrint))
         @if (empty($articleType) or (isset($articleType) and $articleType !== 'exhibition' and $articleType !== 'exhibitionHistory' and $articleType !== 'video'))
-        <li class="m-article-actions__action u-hide@small-">
+        <li class="m-article-actions__action">
             @component('components.atoms._btn')
                 @slot('variation', 'btn--quaternary btn--icon')
                 @slot('font', '')


### PR DESCRIPTION
Show the print icon on all screen sizes and hide all secondary actions on small and xsmall screen sizes.