### PR TITLE
Hide secondary actions on mobile for all generic pages [WEB-3148]

### DIFF
--- a/frontend/scss/organisms/_o-article__primary-actions.scss
+++ b/frontend/scss/organisms/_o-article__primary-actions.scss
@@ -112,12 +112,6 @@
   .o-article__primary-actions {
     padding-top: 0;
 
-    @include breakpoint('small-') {
-      &~.o-article__secondary-actions {
-        display: none;
-      }
-    }
-
     @include breakpoint('medium-') {
       @include background-fill;
 
@@ -154,6 +148,12 @@
 
     .m-link-list {
       margin-top: 0;
+    }
+  }
+
+  .o-article__secondary-actions {
+    @include breakpoint('small-') {
+      display: none;
     }
   }
 }


### PR DESCRIPTION
... instead of just generic pages that have also have primary actions.