### PR TITLE
Fix tag closing bracket in footnote refs

### DIFF
--- a/app/Helpers/StringHelpers.php
+++ b/app/Helpers/StringHelpers.php
@@ -182,9 +182,11 @@ class StringHelpers
             return [$entityMatch[1], $entityMatch[2]];
         }
 
-        // Check if the string ends with styled text, e.g., "<em>Paris Street; Rainy Day</em>"
-        if (preg_match('/(.*)(<([a-z]+)>[^<]+<\/\3>)$/u', $originalText, $entityMatch)) {
-            // If it ends with styled text, use that whole element
+        // Check if the string ends with an HTML element, for examples:
+        // "<em>Paris Street; Rainy Day</em>"
+        // "<a href="/path">Link</a>"
+        if (preg_match('/(.*)(<([a-z]+)[^>]*>[^<]+<\/\3>)$/u', $originalText, $entityMatch)) {
+            // If it ends with an element, use that whole element
             return [$entityMatch[1], $entityMatch[2]];
         }
 
@@ -197,12 +199,6 @@ class StringHelpers
 
         // Fallback for other cases
         if (empty($lastWord)) {
-            // Check if we have HTML tags
-            if (preg_match('/<[^>]+>/', $originalText)) {
-                // Contains HTML tags, don't split
-                return [$originalText, ''];
-            }
-
             // Match the very last character/punctuation
             preg_match('/(.*)(.)$/', $originalText, $textAndPunctuation);
             $beforeLastWord = $textAndPunctuation[1] ?? $originalText;

--- a/app/Libraries/ShortcodeService.php
+++ b/app/Libraries/ShortcodeService.php
@@ -4,7 +4,7 @@ namespace App\Libraries;
 
 class ShortcodeService
 {
-    // Regex101 reference: https://regex101.com/r/mfPWWB/1/
+    // Regex101 reference: https://regex101.com/r/5dOPYU/1
     public const REF_REGEXP = "/(?P<shortcode>(?:(?:\s?\[))(?P<name>ref)(?:\])(?:(?P<content>.*)(?:\[\/ref\])))/uU";
 
     // Regex101 reference: https://regex101.com/r/sZ7wP0

--- a/app/Libraries/ShortcodeService.php
+++ b/app/Libraries/ShortcodeService.php
@@ -7,47 +7,11 @@ class ShortcodeService
     // Regex101 reference: https://regex101.com/r/5dOPYU/1
     public const REF_REGEXP = "/(?P<shortcode>(?:(?:\s?\[))(?P<name>ref)(?:\])(?:(?P<content>.*)(?:\[\/ref\])))/uU";
 
-    // Regex101 reference: https://regex101.com/r/sZ7wP0
-    public const ATTRIBUTE_REGEXP = "/(?<name>\\S+)=[\"']?(?P<value>(?:.(?![\"']?\\s+(?:\\S+)=|[>\"']))+.)[\"']?/u";
-
-    public static function parse_ref($text) // phpcs:ignore PSR1.Methods.CamelCapsMethodName.NotCamelCaps
-    {
-        return self::parse_text_with_regexp($text, self::REF_REGEXP);
-    }
-
     // phpcs:ignore PSR1.Methods.CamelCapsMethodName.NotCamelCaps
-    private static function parse_text_with_regexp($text, $regexp)
+    public static function parse_ref($text)
     {
-        preg_match_all($regexp, $text, $matches, PREG_SET_ORDER);
-        $shortcodes = [];
-
-        foreach ($matches as $i => $value) {
-            $shortcodes[$i]['shortcode'] = $value['shortcode'];
-            $shortcodes[$i]['name'] = $value['name'];
-
-            if (isset($value['attrs'])) {
-                $attrs = self::parse_attrs($value['attrs']);
-                $shortcodes[$i]['attrs'] = $attrs;
-            }
-
-            if (isset($value['content'])) {
-                $shortcodes[$i]['content'] = $value['content'];
-            }
-        }
-
-        return $shortcodes;
-    }
-
-    private static function parse_attrs($attrs) // phpcs:ignore PSR1.Methods.CamelCapsMethodName.NotCamelCaps
-    {
-        preg_match_all(self::ATTRIBUTE_REGEXP, $attrs, $matches, PREG_SET_ORDER);
-        $attributes = [];
-
-        foreach ($matches as $i => $value) {
-            $key = $value['name'];
-            $attributes[$i][$key] = $value['value'];
-        }
-
-        return $attributes;
+        preg_match_all(self::REF_REGEXP, $text, $matches, PREG_SET_ORDER);
+        $filter = fn($captureGroup) => is_string($captureGroup);
+        return array_map(fn ($match) => array_filter($match, $filter, ARRAY_FILTER_USE_KEY), $matches);
     }
 }

--- a/tests/Unit/ShortcodeServiceTest.php
+++ b/tests/Unit/ShortcodeServiceTest.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Libraries\ShortcodeService;
+use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
+
+class ShortcodeServiceTest extends BaseTestCase
+{
+    // Implementing: https://regex101.com/r/5dOPYU/1
+    public function test_REF_REGEXP(): void
+    {
+        $shortcodedHtml = <<<'HTML'
+            <p>Let&#8217;s give him a friend too.[ref]FPO Franklin Rosemont, “Manifesto on the Position and Direction of the Surrealist Movement in the United States,” in&nbsp;<em>Arsenal: Surrealist Subversion</em>, vol. 1, edited by Franklin Rosemont (Chicago: Black Swan Press: 1970), 13.[/ref] Everybody needs a friend. From all of us here, I want to wish you happy painting and God bless, my friends. Everybody&#8217;s different. Trees are different.[ref]FPO Sometimes titled&nbsp;<em>The Secret Voyage (with portrait of Dori and Pancho) (A viagem secreta [com retrato de Dori e Pancho])</em>, my co-curators and I saw this painting in Guedes’s home in Sintra, Portugal. It was not included in&nbsp;<em>Malangatana: Mozambique Modern</em>&nbsp;due to the conservation that would have been required.[/ref] Let them all be individuals.</p><p>That&#8217;s a son of a gun of a cloud. There comes a nice little fluffer. I get carried away with this brush cleaning.</p>
+        HTML;
+        $matches = array();
+        preg_match_all(ShortcodeService::REF_REGEXP, $shortcodedHtml, $matches, PREG_SET_ORDER);
+
+
+        $this->assertRefRegexpMatches(
+            [
+                0 => "[ref]FPO Franklin Rosemont, “Manifesto on the Position and Direction of the Surrealist Movement in the United States,” in&nbsp;<em>Arsenal: Surrealist Subversion</em>, vol. 1, edited by Franklin Rosemont (Chicago: Black Swan Press: 1970), 13.[/ref]",
+                1 => "[ref]FPO Franklin Rosemont, “Manifesto on the Position and Direction of the Surrealist Movement in the United States,” in&nbsp;<em>Arsenal: Surrealist Subversion</em>, vol. 1, edited by Franklin Rosemont (Chicago: Black Swan Press: 1970), 13.[/ref]",
+                2 => "ref",
+                3 => "FPO Franklin Rosemont, “Manifesto on the Position and Direction of the Surrealist Movement in the United States,” in&nbsp;<em>Arsenal: Surrealist Subversion</em>, vol. 1, edited by Franklin Rosemont (Chicago: Black Swan Press: 1970), 13.",
+            ],
+            $matches[0],
+        );
+
+        $this->assertRefRegexpMatches(
+            [
+                0 => "[ref]FPO Sometimes titled&nbsp;<em>The Secret Voyage (with portrait of Dori and Pancho) (A viagem secreta [com retrato de Dori e Pancho])</em>, my co-curators and I saw this painting in Guedes’s home in Sintra, Portugal. It was not included in&nbsp;<em>Malangatana: Mozambique Modern</em>&nbsp;due to the conservation that would have been required.[/ref]",
+                1 => "[ref]FPO Sometimes titled&nbsp;<em>The Secret Voyage (with portrait of Dori and Pancho) (A viagem secreta [com retrato de Dori e Pancho])</em>, my co-curators and I saw this painting in Guedes’s home in Sintra, Portugal. It was not included in&nbsp;<em>Malangatana: Mozambique Modern</em>&nbsp;due to the conservation that would have been required.[/ref]",
+                2 => "ref",
+                3 => "FPO Sometimes titled&nbsp;<em>The Secret Voyage (with portrait of Dori and Pancho) (A viagem secreta [com retrato de Dori e Pancho])</em>, my co-curators and I saw this painting in Guedes’s home in Sintra, Portugal. It was not included in&nbsp;<em>Malangatana: Mozambique Modern</em>&nbsp;due to the conservation that would have been required.",
+            ],
+            $matches[1],
+        );
+    }
+
+    public function assertRefRegexpMatches(array $expected, array $matches): void
+    {
+        foreach (array_keys($expected) as $index) {
+            $this->assertArrayHasKey($index, $matches, "Match $index exists");
+            $this->assertRefRegexpMatchHasGroups($matches);
+        }
+
+        $this->assertEquals(
+            $expected[0],
+            $matches['shortcode'],
+            'The full match is the shortcode',
+        );
+
+        $this->assertEquals(
+            $expected[1],
+            $matches['shortcode'],
+            'The first capture group is a [ref]...[/ref] tag',
+        );
+
+        $this->assertEquals(
+            $expected[2],
+            $matches['name'],
+            'The second capture group is the name of the [ref] tag',
+        );
+
+        $this->assertEquals(
+            $matches[3],
+            $matches['content'],
+            'The third capture group is the content inside the tag',
+        );
+    }
+
+    public function assertRefRegexpMatchHasGroups(array $match): void
+    {
+        foreach (['shortcode', 'name', 'content'] as $group) {
+            $this->assertArrayHasKey($group, $match, "Match group $group exists");
+        }
+    }
+}

--- a/tests/Unit/ShortcodeServiceTest.php
+++ b/tests/Unit/ShortcodeServiceTest.php
@@ -7,73 +7,48 @@ use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
 
 class ShortcodeServiceTest extends BaseTestCase
 {
-    // Implementing: https://regex101.com/r/5dOPYU/1
-    public function test_REF_REGEXP(): void
+    public function test_parse_ref(): void
     {
-        $shortcodedHtml = <<<'HTML'
+        [$parsedRef] = ShortcodeService::parse_ref('<p>[ref]text[/ref]</p>');
+        $this->assertArrayHasKey('shortcode', $parsedRef, 'The shortcode is a [tag]...[/tag] with content');
+        $this->assertArrayHasKey('name', $parsedRef, 'The tag has a name');
+        $this->assertArrayHasKey('content', $parsedRef, 'There is content inside the tag');
+    }
+
+    // Implementing: https://regex101.com/r/5dOPYU/1
+    public function test_parse_ref_with_multiple_tags(): void
+    {
+        $htmlWithRefs = <<<'HTML'
             <p>Let&#8217;s give him a friend too.[ref]FPO Franklin Rosemont, “Manifesto on the Position and Direction of the Surrealist Movement in the United States,” in&nbsp;<em>Arsenal: Surrealist Subversion</em>, vol. 1, edited by Franklin Rosemont (Chicago: Black Swan Press: 1970), 13.[/ref] Everybody needs a friend. From all of us here, I want to wish you happy painting and God bless, my friends. Everybody&#8217;s different. Trees are different.[ref]FPO Sometimes titled&nbsp;<em>The Secret Voyage (with portrait of Dori and Pancho) (A viagem secreta [com retrato de Dori e Pancho])</em>, my co-curators and I saw this painting in Guedes’s home in Sintra, Portugal. It was not included in&nbsp;<em>Malangatana: Mozambique Modern</em>&nbsp;due to the conservation that would have been required.[/ref] Let them all be individuals.</p><p>That&#8217;s a son of a gun of a cloud. There comes a nice little fluffer. I get carried away with this brush cleaning.</p>
         HTML;
-        $matches = array();
-        preg_match_all(ShortcodeService::REF_REGEXP, $shortcodedHtml, $matches, PREG_SET_ORDER);
 
+        $parsedRefs = ShortcodeService::parse_ref($htmlWithRefs);
+        $this->assertCount(2, $parsedRefs);
 
-        $this->assertRefRegexpMatches(
-            [
-                0 => "[ref]FPO Franklin Rosemont, “Manifesto on the Position and Direction of the Surrealist Movement in the United States,” in&nbsp;<em>Arsenal: Surrealist Subversion</em>, vol. 1, edited by Franklin Rosemont (Chicago: Black Swan Press: 1970), 13.[/ref]",
-                1 => "[ref]FPO Franklin Rosemont, “Manifesto on the Position and Direction of the Surrealist Movement in the United States,” in&nbsp;<em>Arsenal: Surrealist Subversion</em>, vol. 1, edited by Franklin Rosemont (Chicago: Black Swan Press: 1970), 13.[/ref]",
-                2 => "ref",
-                3 => "FPO Franklin Rosemont, “Manifesto on the Position and Direction of the Surrealist Movement in the United States,” in&nbsp;<em>Arsenal: Surrealist Subversion</em>, vol. 1, edited by Franklin Rosemont (Chicago: Black Swan Press: 1970), 13.",
-            ],
-            $matches[0],
-        );
-
-        $this->assertRefRegexpMatches(
-            [
-                0 => "[ref]FPO Sometimes titled&nbsp;<em>The Secret Voyage (with portrait of Dori and Pancho) (A viagem secreta [com retrato de Dori e Pancho])</em>, my co-curators and I saw this painting in Guedes’s home in Sintra, Portugal. It was not included in&nbsp;<em>Malangatana: Mozambique Modern</em>&nbsp;due to the conservation that would have been required.[/ref]",
-                1 => "[ref]FPO Sometimes titled&nbsp;<em>The Secret Voyage (with portrait of Dori and Pancho) (A viagem secreta [com retrato de Dori e Pancho])</em>, my co-curators and I saw this painting in Guedes’s home in Sintra, Portugal. It was not included in&nbsp;<em>Malangatana: Mozambique Modern</em>&nbsp;due to the conservation that would have been required.[/ref]",
-                2 => "ref",
-                3 => "FPO Sometimes titled&nbsp;<em>The Secret Voyage (with portrait of Dori and Pancho) (A viagem secreta [com retrato de Dori e Pancho])</em>, my co-curators and I saw this painting in Guedes’s home in Sintra, Portugal. It was not included in&nbsp;<em>Malangatana: Mozambique Modern</em>&nbsp;due to the conservation that would have been required.",
-            ],
-            $matches[1],
-        );
-    }
-
-    public function assertRefRegexpMatches(array $expected, array $matches): void
-    {
-        foreach (array_keys($expected) as $index) {
-            $this->assertArrayHasKey($index, $matches, "Match $index exists");
-            $this->assertRefRegexpMatchHasGroups($matches);
-        }
-
+        [$firstRef, $secondRef] = $parsedRefs;
         $this->assertEquals(
-            $expected[0],
-            $matches['shortcode'],
-            'The full match is the shortcode',
+            '[ref]FPO Franklin Rosemont, “Manifesto on the Position and Direction of the Surrealist Movement in the United States,” in&nbsp;<em>Arsenal: Surrealist Subversion</em>, vol. 1, edited by Franklin Rosemont (Chicago: Black Swan Press: 1970), 13.[/ref]',
+            $firstRef['shortcode'],
         );
-
         $this->assertEquals(
-            $expected[1],
-            $matches['shortcode'],
-            'The first capture group is a [ref]...[/ref] tag',
+            'ref',
+            $firstRef['name'],
         );
-
         $this->assertEquals(
-            $expected[2],
-            $matches['name'],
-            'The second capture group is the name of the [ref] tag',
+            'FPO Franklin Rosemont, “Manifesto on the Position and Direction of the Surrealist Movement in the United States,” in&nbsp;<em>Arsenal: Surrealist Subversion</em>, vol. 1, edited by Franklin Rosemont (Chicago: Black Swan Press: 1970), 13.',
+            $firstRef['content'],
         );
-
         $this->assertEquals(
-            $matches[3],
-            $matches['content'],
-            'The third capture group is the content inside the tag',
+            '[ref]FPO Sometimes titled&nbsp;<em>The Secret Voyage (with portrait of Dori and Pancho) (A viagem secreta [com retrato de Dori e Pancho])</em>, my co-curators and I saw this painting in Guedes’s home in Sintra, Portugal. It was not included in&nbsp;<em>Malangatana: Mozambique Modern</em>&nbsp;due to the conservation that would have been required.[/ref]',
+            $secondRef['shortcode'],
         );
-    }
-
-    public function assertRefRegexpMatchHasGroups(array $match): void
-    {
-        foreach (['shortcode', 'name', 'content'] as $group) {
-            $this->assertArrayHasKey($group, $match, "Match group $group exists");
-        }
+        $this->assertEquals(
+            'ref',
+            $secondRef['name'],
+        );
+        $this->assertEquals(
+            'FPO Sometimes titled&nbsp;<em>The Secret Voyage (with portrait of Dori and Pancho) (A viagem secreta [com retrato de Dori e Pancho])</em>, my co-curators and I saw this painting in Guedes’s home in Sintra, Portugal. It was not included in&nbsp;<em>Malangatana: Mozambique Modern</em>&nbsp;due to the conservation that would have been required.',
+            $secondRef['content'],
+        );
     }
 }

--- a/tests/Unit/StringHelpersTest.php
+++ b/tests/Unit/StringHelpersTest.php
@@ -23,6 +23,13 @@ class StringHelpersTest extends BaseTestCase
         $this->assertEquals('<em>Text in ending tag</em>', $lastWord);
     }
 
+    public function test_getLastWord_finds_last_tag_with_attributes(): void
+    {
+        [$beforeLastWord, $lastWord] = StringHelpers::getLastWord('Text not in a link <a id="id" href="/path">Text in a link</a>');
+        $this->assertEquals('Text not in a link ', $beforeLastWord);
+        $this->assertEquals('<a id="id" href="/path">Text in a link</a>', $lastWord);
+    }
+
     public function test_getLastWord_finds_non_html_non_space_character(): void
     {
         [$beforeLastWord, $lastWord] = StringHelpers::getLastWord('Text ending with a non-html, non-space character. ');

--- a/tests/Unit/StringHelpersTest.php
+++ b/tests/Unit/StringHelpersTest.php
@@ -37,6 +37,52 @@ class StringHelpersTest extends BaseTestCase
         $this->assertEquals('.', $lastWord);
     }
 
+    public function test_convertReferenceLinks(): void
+    {
+        $refs = [
+            '[ref]Reference 1.[/ref]',
+            '[ref]Reference 2.[/ref]',
+        ];
+        $htmlWithRefs = "<p>Text before reference one $refs[0]. Text before reference two$refs[1]</p>";
+
+        [$convertedHtml, $collectedRefs] = StringHelpers::convertReferenceLinks($htmlWithRefs, []);
+        foreach ($refs as $index => $ref) {
+            $id = $index + 1;
+
+            $this->assertStringNotContainsString(
+                $ref,
+                $convertedHtml,
+                'The [ref]...[/ref] shortcode tag has been removed',
+            );
+            $this->assertStringContainsString(
+                "<sup id=\"ref_cite-$id\">",
+                $convertedHtml,
+                'The reference has a citation id',
+            );
+            $this->assertStringContainsString(
+                "<a href=\"#ref_note-$id\">",
+                $convertedHtml,
+                'The reference has a footnote link',
+            );
+            $this->assertStringContainsString(
+                "[$id]",
+                $convertedHtml,
+                'The reference has a number'
+            );
+
+            $this->assertEquals(
+                $id,
+                $collectedRefs[$index]['id'],
+                'The collected reference has an id',
+            );
+            $this->assertStringContainsString(
+                $collectedRefs[$index]['reference'],
+                $ref,
+                'The collected reference contains the [ref]...[/ref] contents',
+            );
+        }
+    }
+
     public static function htmlEntities(): array
     {
         return array_map(


### PR DESCRIPTION
This change fixes the `StringHelpers::getLastWord()` regex for detecting HTML elements (and reverts @web-dev-trev's [recent change](https://github.com/art-institute-of-chicago/artic.edu/pull/918)). I also refactored `ShortcodeService` to remove unused code.