### PR TITLE
Update logic for LIV viewer sizing/hiding [PUB-336]

### DIFF
--- a/frontend/js/behaviors/layeredImageViewer/layeredImageViewer.js
+++ b/frontend/js/behaviors/layeredImageViewer/layeredImageViewer.js
@@ -1337,6 +1337,7 @@ const layeredImageViewer = function(container) {
   const updateDimensions = () => {
     figCaption = container.querySelector('figcaption');
     container.style.height = 'max-content'
+    container.offsetHeight;
 
     if (figCaption !== null && (container.offsetHeight > figCaption.offsetHeight) && !isSized) {
 


### PR DESCRIPTION
I lightened and simplified the behaviors here. I was trying to find something to hook into and found that the figcaption gets generated later along with the viewer once it gets built. So now we'll use that as a point of knowing the LIV is updated and trigger the resizing.