### PR TITLE
Videos and playlists interface [WEB-3179]

### DIFF
--- a/app/Console/Commands/ImportYouTubeData.php
+++ b/app/Console/Commands/ImportYouTubeData.php
@@ -91,6 +91,7 @@ class ImportYouTubeData extends Command
                     'list_description' => $source['snippet']['description'],
                     'uploaded_at' => $source['snippet']['publishedAt'],
                     'duration' => $this->convertDuration($source['contentDetails']['duration']),
+                    'thumbnail_url' => $source['snippet']['thumbnails']['high']['url'],
                 ]);
                 $video->save();
                 $progress->advance();
@@ -109,11 +110,12 @@ class ImportYouTubeData extends Command
         $progress->start();
         foreach ($this->playlists() as $sourcePlaylist) {
             $playlistId = $sourcePlaylist['id'];
-            $playlist = Playlist::firstOrCreate(
+            $playlist = Playlist::updateOrCreate(
                 ['youtube_id' =>  $playlistId],
                 [
                     'youtube_id' =>  $playlistId,
                     'title' => $sourcePlaylist['snippet']['title'],
+                    'thumbnail_url' => $sourcePlaylist['snippet']['thumbnails']['high']['url'],
                 ],
             );
             $sourcePlaylistItems = $this->itemsInPlaylist($playlistId)->all();

--- a/app/Http/Controllers/Twill/PlaylistController.php
+++ b/app/Http/Controllers/Twill/PlaylistController.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace App\Http\Controllers\Twill;
+
+use A17\Twill\Services\Listings\Columns\Relation;
+use A17\Twill\Services\Listings\Columns\Text;
+use A17\Twill\Services\Listings\TableColumns;
+use App\Models\Playlist;
+
+class PlaylistController extends BaseController
+{
+    protected function setUpController(): void
+    {
+        $this->disableCreate();
+        $this->disableDelete();
+        $this->disablePermalink();
+        $this->setModuleName('playlists');
+        $this->setSearchColumns(['title', 'youtube_id']);
+    }
+
+    protected function getIndexTableColumns(): TableColumns
+    {
+        $columns = parent::getIndexTableColumns();
+        $afterFirstColumn = $columns->splice(1);
+        $columns->push(
+            Text::make()
+                ->field('thumbnail_url')
+                ->title(null)
+                ->renderHtml()
+                ->customRender(fn (Playlist $playlist) => "<img style='max-width: 80px' src='$playlist->thumbnail_url' />")
+        );
+
+        return $columns->merge($afterFirstColumn);
+    }
+
+    protected function additionalIndexTableColumns(): TableColumns
+    {
+        $columns = TableColumns::make();
+        $columns->add(
+            Relation::make()
+                ->relation('videos')
+                ->field('title')
+                ->title('Videos')
+                ->optional()
+        );
+        $columns->add(
+            Text::make()
+                ->field('youtube_id')
+                ->title('YouTube ID')
+                ->optional()
+                ->hide()
+                ->linkCell(fn (Playlist $playlist) => $playlist->source_url)
+        );
+
+        return $columns;
+    }
+}

--- a/app/Http/Controllers/Twill/VideoController.php
+++ b/app/Http/Controllers/Twill/VideoController.php
@@ -2,14 +2,67 @@
 
 namespace App\Http\Controllers\Twill;
 
+use A17\Twill\Services\Listings\Columns\Relation;
+use A17\Twill\Services\Listings\Columns\Text;
+use A17\Twill\Services\Listings\TableColumns;
+use App\Models\Video;
 use App\Repositories\CategoryRepository;
 
 class VideoController extends BaseController
 {
     protected function setUpController(): void
     {
+        $this->disableCreate();
         $this->setModuleName('videos');
         $this->setPreviewView('site.videoDetail');
+        $this->setSearchColumns(['title', 'youtube_id']);
+    }
+
+    protected function getIndexTableColumns(): TableColumns
+    {
+        $columns = parent::getIndexTableColumns();
+        $afterFirstColumn = $columns->splice(1);
+        $columns->push(
+            Text::make()
+                ->field('thumbnail_url')
+                ->title(null)
+                ->renderHtml()
+                ->customRender(fn (Video $video) => "<img style='max-width: 80px' src='$video->thumbnail_url' />")
+        );
+
+        return $columns->merge($afterFirstColumn);
+    }
+
+    protected function additionalIndexTableColumns(): TableColumns
+    {
+        $columns = TableColumns::make();
+        $columns->add(
+            Text::make()
+                ->field('duration')
+        );
+        $columns->add(
+            Text::make()
+                ->field('uploaded_at')
+                ->sortable()
+                ->customRender(fn (Video $video) => (string) $video->uploaded_at?->format('M j, Y'))
+        );
+        $columns->add(
+            Relation::make()
+                ->relation('playlists')
+                ->field('title')
+                ->title('Playlists')
+                ->optional()
+        );
+        $columns->add(
+            Text::make()
+                ->field('youtube_id')
+                ->title('YouTube ID')
+                ->optional()
+                ->hide()
+                ->linkCell(fn (Video $video) => $video->source_url)
+        );
+
+        return $columns;
     }
 
     protected function formData($request)

--- a/app/Http/Requests/Twill/PlaylistRequest.php
+++ b/app/Http/Requests/Twill/PlaylistRequest.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Http\Requests\Twill;
+
+use A17\Twill\Http\Requests\Admin\Request;
+
+class PlaylistRequest extends Request
+{
+    public function rulesForCreate()
+    {
+        return [];
+    }
+
+    public function rulesForUpdate()
+    {
+        return [];
+    }
+}

--- a/app/Models/Playlist.php
+++ b/app/Models/Playlist.php
@@ -2,16 +2,20 @@
 
 namespace App\Models;
 
+use A17\Twill\Models\Behaviors\HasRelated;
+use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 
 class Playlist extends AbstractModel
 {
     use HasFactory;
+    use HasRelated;
 
     protected $fillable = [
         'published',
         'title',
         'youtube_id',
+        'thumbnail_url',
     ];
 
     protected $casts = [
@@ -22,11 +26,22 @@ class Playlist extends AbstractModel
         'published' => false,
     ];
 
+    public $appends = [
+        'source_url',
+    ];
+
     public function videos()
     {
         return $this->belongsToMany(Video::class)
             ->withTimestamps()
             ->withPivot('position')
             ->orderByPivot('position');
+    }
+
+    public function sourceUrl(): Attribute
+    {
+        return Attribute::make(
+            get: fn ($_, array $attributes) => "https://youtube.com/playlist?list={$attributes['youtube_id']}",
+        );
     }
 }

--- a/app/Models/Video.php
+++ b/app/Models/Video.php
@@ -2,7 +2,6 @@
 
 namespace App\Models;
 
-use Illuminate\Database\Eloquent\Builder;
 use A17\Twill\Models\Behaviors\HasFiles;
 use A17\Twill\Models\Behaviors\HasRevisions;
 use A17\Twill\Models\Behaviors\HasSlug;
@@ -11,6 +10,8 @@ use App\Models\Behaviors\HasBlocks;
 use App\Models\Behaviors\HasMedias;
 use App\Models\Behaviors\HasMediasEloquent;
 use App\Models\Behaviors\HasRelated;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Casts\Attribute;
 
 class Video extends AbstractModel
 {
@@ -42,6 +43,7 @@ class Video extends AbstractModel
         'toggle_autorelated',
         'youtube_id',
         'uploaded_at',
+        'thumbnail_url',
     ];
 
     protected $casts = [
@@ -60,6 +62,7 @@ class Video extends AbstractModel
 
     protected $appends = [
         'embed',
+        'source_url',
     ];
 
     public $mediasParams = [
@@ -87,6 +90,13 @@ class Video extends AbstractModel
         return $this->belongsToMany(Playlist::class)
             ->withTimestamps()
             ->withPivot('position');
+    }
+
+    public function sourceUrl(): Attribute
+    {
+        return Attribute::make(
+            get: fn ($_, array $attributes) => "https://youtube.com/watch?v={$attributes['youtube_id']}",
+        );
     }
 
     public function scopeByCategories($query, $categories = null): Builder

--- a/app/Repositories/PlaylistRepository.php
+++ b/app/Repositories/PlaylistRepository.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Repositories;
+
+use App\Models\Playlist;
+use Illuminate\Database\Eloquent\Builder;
+
+class PlaylistRepository extends ModuleRepository
+{
+    protected $browsers = [
+        'videos' => [
+            'routePrefix' => 'collection.articlesPublications',
+        ],
+    ];
+
+    public function __construct(Playlist $model)
+    {
+        $this->model = $model;
+    }
+
+    public function order($query, array $orders = []): Builder
+    {
+        // Default sort by title instead of created_at.
+        $orders['title'] ??= 'asc';
+        unset($orders['created_at']);
+        return parent::order($query, $orders);
+    }
+}

--- a/app/Repositories/VideoRepository.php
+++ b/app/Repositories/VideoRepository.php
@@ -9,6 +9,7 @@ use A17\Twill\Repositories\Behaviors\HandleMedias;
 use A17\Twill\Repositories\Behaviors\HandleRevisions;
 use A17\Twill\Repositories\Behaviors\HandleSlugs;
 use App\Models\Video;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Collection;
 
 class VideoRepository extends ModuleRepository
@@ -19,6 +20,12 @@ class VideoRepository extends ModuleRepository
     use HandleFiles;
     use HandleRevisions;
 
+    protected $browsers = [
+        'playlists' => [
+            'routePrefix' => 'collection.articlesPublications',
+        ],
+    ];
+
     protected $relatedBrowsers = [
         'related_videos' => [
             'relation' => 'related_videos'
@@ -28,6 +35,14 @@ class VideoRepository extends ModuleRepository
     public function __construct(Video $model)
     {
         $this->model = $model;
+    }
+
+    public function order($query, array $orders = []): Builder
+    {
+        // Default sort by uploaded_at instead of created_at.
+        $orders['uploaded_at'] ??= 'desc';
+        unset($orders['created_at']);
+        return parent::order($query, $orders);
     }
 
     public function getShowData($item, $slug = null, $previewPage = null): array

--- a/config/twill-navigation.php
+++ b/config/twill-navigation.php
@@ -136,6 +136,10 @@ $nav = [
                         'title' => 'Videos',
                         'module' => true,
                     ],
+                    'playlists' => [
+                        'title' => 'Playlists',
+                        'module' => true,
+                    ],
                     'printedPublications' => [
                         'title' => 'Print Publications',
                         'module' => true,

--- a/database/factories/PlaylistFactory.php
+++ b/database/factories/PlaylistFactory.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Playlist;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class PlaylistFactory extends Factory
+{
+    protected $model = Playlist::class;
+
+    public function definition(): array
+    {
+        return [
+        ];
+    }
+}

--- a/database/migrations/2025_09_17_142145_add_thumbnail_url_columns_to_playlists_and_videos_tables.php
+++ b/database/migrations/2025_09_17_142145_add_thumbnail_url_columns_to_playlists_and_videos_tables.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('playlists', function (Blueprint $table) {
+            $table->string('thumbnail_url')->nullable();
+        });
+        Schema::table('videos', function (Blueprint $table) {
+            $table->string('thumbnail_url')->nullable();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('videos', function (Blueprint $table) {
+            $table->dropColumn('thumbnail_url');
+        });
+        Schema::table('playlists', function (Blueprint $table) {
+            $table->dropColumn('thumbnail_url');
+        });
+    }
+};

--- a/resources/views/twill/playlists/form.blade.php
+++ b/resources/views/twill/playlists/form.blade.php
@@ -1,0 +1,41 @@
+@extends('twill::layouts.form')
+
+@section('contentFields')
+    <x-twill::input
+        name='title'
+        label='Title'
+        disabled='true'
+    />
+
+    <x-twill::formColumns>
+        <x-slot:left>
+            <img
+                style="margin-top: 35px; width: 100%"
+                src='{{ $item->thumbnail_url }}'
+            />
+        </x-slot:left>
+        <x-slot:right>
+        </x-slot:right>
+    </x-twill::formColumns>
+@stop
+
+@section('sideFieldsets')
+    <a17-fieldset title="YouTube" id="youtube">
+        <x-twill::input
+            name='youtube_id'
+            label='YouTube ID'
+            disabled='true'
+        />
+        <a href="{{ $item->source_url }}" target="_blank">🔗 YouTube</a>
+
+        <x-twill::browser
+            name='videos'
+            label='Videos'
+            note='Read-only'
+            module-name='videos'
+            route-prefix='collection.articlesPublications'
+            disabled='true'
+            itemLabel=''
+        />
+    </a17-fieldset>
+@endsection

--- a/resources/views/twill/videos/form.blade.php
+++ b/resources/views/twill/videos/form.blade.php
@@ -16,19 +16,30 @@
     <x-twill::input
         name='video_url'
         label='Video URL'
+        disabled='true'
     />
 
     <x-twill::input
         name='duration'
         label='Duration'
-        note='e.g. 3:45'
+        disabled='true'
     />
 
-    <x-twill::medias
-        label='Hero Image'
-        name='hero'
-        note='Minimum image width 3000px'
-    />
+    <x-twill::formColumns>
+        <x-slot:left>
+            <img
+                style="margin-top: 35px; width: 100%"
+                src='{{ $item->thumbnail_url }}'
+            />
+        </x-slot:left>
+        <x-slot:right>
+            <x-twill::medias
+                label='Hero Image'
+                name='hero'
+                note='Minimum image width 3000px'
+            />
+        </x-slot:right>
+    </x-twill::formColumns>
 
     <x-twill::date-picker
         name='date'
@@ -115,4 +126,31 @@
 
     @include('twill.partials.related')
 
+@endsection
+
+@section('sideFieldsets')
+    <a17-fieldset title="YouTube" id="youtube">
+        <x-twill::input
+            name='youtube_id'
+            label='YouTube ID'
+            disabled='true'
+        />
+        <a href="{{ $item->source_url }}" target="_blank">🔗 YouTube</a>
+
+        <x-twill::input
+            name='uploaded_at'
+            label='Uploaded At'
+            disabled='true'
+        />
+
+        <x-twill::browser
+            name='playlists'
+            label='Playlists'
+            note='Read-only'
+            module-name='playlists'
+            route-prefix='collection.articlesPublications'
+            disabled='true'
+            itemLabel=''
+        />
+    </a17-fieldset>
 @endsection

--- a/routes/twill.php
+++ b/routes/twill.php
@@ -84,6 +84,7 @@ Route::group(['prefix' => 'collection'], function () {
         TwillRoutes::module('articles');
         TwillRoutes::module('categories');
         TwillRoutes::module('videos');
+        TwillRoutes::module('playlists');
         TwillRoutes::module('printedPublications');
         TwillRoutes::module('digitalPublications');
         TwillRoutes::module('digitalPublications.articles');


### PR DESCRIPTION
This change includes the following to create a CMS interface for YouTube data:
* Update videos index table to show thumbnail, duration, playlists, and YT id
* Update video edit page fields
* Create playlists index table to show thumbnail, title, and videos
* Create playlist edit page
* Add YT metadata to sidebar of video / playlist edit pages