### PR TITLE
Render target on accordions only in preview mode [WEB-3201]

### DIFF
--- a/resources/views/site/blocks/ranged_accordion.blade.php
+++ b/resources/views/site/blocks/ranged_accordion.blade.php
@@ -11,6 +11,9 @@
             <svg class="icon--minus"><use xlink:href="#icon--minus" /></svg>
         </span>
     </button></h3>
+    @if(request()->is('*preview*'))
+      accordion_{{ StringHelpers::getUtf8Slug($title.'-'.$block->id) }}
+    @endif
     <div id="panel_accordion_{{ StringHelpers::getUtf8Slug($title.'-'.$block->id) }}" class="o-accordion__panel" aria-labelledby="{{ StringHelpers::getUtf8Slug($title)}}">
         <div class="o-accordion__panel-content o-blocks o-blocks--with-sidebar">
             {!! $renderData->renderChildren('accordion_items') !!}


### PR DESCRIPTION
The alternative way to determine if it's in preview is:

`View::share('previewMode', true));`

and then do an if (isset($previewMode) && $previewMode))

The expected $isPreview variable is only top-level accessible which is ew