### PR TITLE
Fix fallback for tools for teaching LP

### DIFF
--- a/resources/views/site/blocks/editorial_block.blade.php
+++ b/resources/views/site/blocks/editorial_block.blade.php
@@ -31,7 +31,7 @@
                       ];
 
                       foreach ($imageFallbacks as [$field, $crop, $source]) {
-                          if ($source->hasImage($field)) {
+                          if ($source->hasImage($field) && !empty($source->imageAsArray($field, $crop))) {
                               return $source->imageAsArray($field, $crop);
                           }
                       }


### PR DESCRIPTION
This will evaluate if the crop is substantial before returning it. Some crops match the params as they exist in the config but didn't have any data.