### PR TITLE
Reimplement videos.index route [WEB-3214]

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -116,7 +116,9 @@ Route::get('/authors/{id}/{slug?}', [AuthorController::class, 'show'])->name('au
 
 // Videos routes
 // TODO: uncomment when video show page is reimplemented
-Route::get('/videos', [VideoController::class, 'index'])->name('videos.index');
+Route::get('videos', function () {
+    return abort(404);
+})->name('videos');
 Route::get('/videos/{id}/{slug?}', [VideoController::class, 'show'])->name('videos.show');
 
 // Mirador kiosk routes


### PR DESCRIPTION
I didn't think this was necessary since there is a vanity redirect for this route:
https://admin.www.artic.edu/general/vanityRedirects?sortKey=&sortDir=asc&page=1&offset=20&columns[]=bulk&columns[]=published&columns[]=path&columns[]=destination&filter=%7B%22status%22:%22all%22,%22search%22:%22videos%22%7D