### PR TITLE
Remove type hint from helper function [WEB-3249]

### DIFF
--- a/app/Console/Commands/YouTubeVideosAndPlaylists.php
+++ b/app/Console/Commands/YouTubeVideosAndPlaylists.php
@@ -174,7 +174,7 @@ class YouTubeVideosAndPlaylists extends AbstractYoutubeCommand
     /**
      * Retrieve the highest resolution thumbnail of those provided.
      */
-    private function highestResolutionThumbnail(array $thumbnails): string
+    private function highestResolutionThumbnail($thumbnails): string
     {
         $resolutions = ['maxres', 'standard', 'high'];
         foreach ($resolutions as $resolution) {


### PR DESCRIPTION
This change addresses an issue I was seeing when attempting to manually run the YouTube import command on www-test.