### PR TITLE
VQA - Playlist Detail heading [WEB-3301]

### DIFF
--- a/frontend/scss/pages/types/_t-videos.scss
+++ b/frontend/scss/pages/types/_t-videos.scss
@@ -612,21 +612,30 @@
 }
 
 .p-playlistvideo-show body {
-    .playlist-title {
+    .playlist-header {
         color: $color__videos__text--secondary;
         font-family: $sans-serif-font--loaded;
-        font-size: 21px;
         font-style: normal;
-        font-weight: 325;
-        letter-spacing: 1.68px;
-        line-height: 28px;
         margin-bottom: 16px;
         margin-top: 56px;
-        text-transform: uppercase;
 
         & ~ .hr {
             margin: 24px 0;
         }
+    }
+    .playlist-prefix,
+    .playlist-title {
+        font-size: 21px;
+        font-weight: 325;
+        letter-spacing: 1.68px;
+        line-height: 28px;
+        text-transform: uppercase;
+    }
+    .video-count {
+        font-size: 18px;
+        font-weight: 300;
+        line-height: 28px;
+        letter-spacing: 0.18px;
     }
     .o-article__header {
         display: grid;

--- a/frontend/scss/pages/types/_t-videos.scss
+++ b/frontend/scss/pages/types/_t-videos.scss
@@ -380,10 +380,12 @@
             display: none;
         }
         .o-article__primary-actions--video {
+            margin: unset;
             min-height: unset;
+            padding: unset;
         }
         .m-article-header--video {
-            gap: 40px;
+            gap: 24px;
             justify-content: unset;
             margin-bottom: 56px !important;
             margin-top: 56px;

--- a/resources/views/site/blocks/playlist_grid.blade.php
+++ b/resources/views/site/blocks/playlist_grid.blade.php
@@ -17,7 +17,7 @@
             $width = '3';
             break;
     }
-    $playlists = $block->getRelated('playlists');
+    $playlists = $block->getRelated('playlists')->where('published', true);
 @endphp
 
 <div class="o-grid-block playlist-grid">

--- a/resources/views/site/videoDetail.blade.php
+++ b/resources/views/site/videoDetail.blade.php
@@ -2,8 +2,16 @@
 
 @section('content')
     @if (isset($playlist))
-        <div class="playlist-title">
-            Playlist: {{ $playlist->title }}
+        <div class="playlist-header">
+            <span class="playlist-prefix">
+                Playlist:
+            </span>
+            <span class="playlist-title">
+                {{ $playlist->title }}
+            </span>
+            <span class="video-count">
+                ({{ $playlist->videos()->published()->count() }} videos)
+            </span>
         </div>
         @component('components.atoms._hr')@endcomponent
     @endif

--- a/routes/web.php
+++ b/routes/web.php
@@ -213,11 +213,18 @@ Route::get('/videos/shorts/{video}', [ShortsController::class, 'show'])->name('s
 Route::get('/videos/shorts/{video}/previous', [ShortsController::class, 'previous'])->name('shorts.previous');
 Route::get('/videos/shorts/{video}/next', [ShortsController::class, 'next'])->name('shorts.next');
 Route::get('/videos/{video}/{slug?}', [VideoController::class, 'show'])->name('videos.show');
-Route::get('/playlists/{playlist}', [PlaylistController::class, 'show'])->name('playlists.show');
-Route::get(
-    '/playlists/{playlist}/videos/{video}/{slug?}',
-    [PlaylistVideoController::class, 'show'],
-)->scopeBindings()->name('playlists.videos.show');
+Route::group([
+    'middleware' => [SanitizeQueryParameters::class],
+    'allowed_query_params' => [
+        'darkMode',
+    ]
+], function () {
+    Route::get('/playlists/{playlist}', [PlaylistController::class, 'show'])->name('playlists.show');
+    Route::get(
+        '/playlists/{playlist}/videos/{video}/{slug?}',
+        [PlaylistVideoController::class, 'show'],
+    )->scopeBindings()->name('playlists.videos.show');
+});
 
 // Mirador kiosk routes
 Route::get('mirador', function () {

--- a/routes/web.php
+++ b/routes/web.php
@@ -213,18 +213,11 @@ Route::get('/videos/shorts/{video}', [ShortsController::class, 'show'])->name('s
 Route::get('/videos/shorts/{video}/previous', [ShortsController::class, 'previous'])->name('shorts.previous');
 Route::get('/videos/shorts/{video}/next', [ShortsController::class, 'next'])->name('shorts.next');
 Route::get('/videos/{video}/{slug?}', [VideoController::class, 'show'])->name('videos.show');
-Route::group([
-    'middleware' => [SanitizeQueryParameters::class],
-    'allowed_query_params' => [
-        'darkMode',
-    ]
-], function () {
-    Route::get('/playlists/{playlist}', [PlaylistController::class, 'show'])->name('playlists.show');
-    Route::get(
-        '/playlists/{playlist}/videos/{video}/{slug?}',
-        [PlaylistVideoController::class, 'show'],
-    )->scopeBindings()->name('playlists.videos.show');
-});
+Route::get('/playlists/{playlist}', [PlaylistController::class, 'show'])->name('playlists.show');
+Route::get(
+    '/playlists/{playlist}/videos/{video}/{slug?}',
+    [PlaylistVideoController::class, 'show'],
+)->scopeBindings()->name('playlists.videos.show');
 
 // Mirador kiosk routes
 Route::get('mirador', function () {


### PR DESCRIPTION
This change addresses these issues with the playlist details:
- ~allow `darkMode` query param in playlist routes~
- display video count in playlist header
- adjust spacing between video title and share icon

Also, for the landing page:
- only display published playlists