### PR TITLE
Make sure the tabbed details header underline is continuous [WEB-3301]

### DIFF
--- a/frontend/scss/pages/types/_t-videos.scss
+++ b/frontend/scss/pages/types/_t-videos.scss
@@ -474,9 +474,8 @@
                 letter-spacing: 1.68px;
                 line-height: 28px;
                 padding-bottom: 22px;
-                padding-left: 0px;
+                padding-left: 15px;
                 padding-right: 15px;
-                margin-right: 15px;
                 text-transform: uppercase;
             }
             .o-tabbed-details__tab[open] .o-tabbed-details__tab-title {


### PR DESCRIPTION
Previously:
<img width="653" height="72" alt="Screenshot 2026-03-03 at 11 46 26 AM" src="https://github.com/user-attachments/assets/7192d190-0e77-478e-9f40-88e9d1155d2a" />

Now:
<img width="666" height="77" alt="Screenshot 2026-03-03 at 11 46 47 AM" src="https://github.com/user-attachments/assets/59243da0-af01-4056-9127-19b798a415c4" />
