### PR TITLE
VQA - Playlist Detail - Adjust the playlist layout for small and medium sizes [WEB-3301]

### DIFF
--- a/frontend/scss/organisms/_o-playlist.scss
+++ b/frontend/scss/organisms/_o-playlist.scss
@@ -33,7 +33,6 @@
             align-self: stretch;
             flex: 1 0 0;
             margin: unset;
-            overflow: hidden;
 
             &::before {
                 display: none;

--- a/frontend/scss/organisms/_o-playlist.scss
+++ b/frontend/scss/organisms/_o-playlist.scss
@@ -21,13 +21,15 @@
             padding: 12px;
         }
         .m-listing__img {
+            max-height: 56px;
             width: 100px;
         }
         .m-listing__meta {
+            max-height: 56px;
             flex: unset;
             flex-flow: unset;
             min-height: inherit;
-
+            overflow: hidden;
         }
         .m-listing__meta .title {
             align-self: stretch;

--- a/frontend/scss/organisms/_o-playlist.scss
+++ b/frontend/scss/organisms/_o-playlist.scss
@@ -7,6 +7,7 @@
         display: flex;
         flex-direction: column;
         gap: 8px;
+        width: 100%;
     }
     .playlist-video {
         width: 100%;

--- a/frontend/scss/pages/types/_t-videos.scss
+++ b/frontend/scss/pages/types/_t-videos.scss
@@ -739,7 +739,6 @@
             font-weight: 325;
             letter-spacing: 0.15px;
             line-height: 20px;
-            text-overflow: ellipsis;
         }
     }
     .o-article__body {

--- a/frontend/scss/pages/types/_t-videos.scss
+++ b/frontend/scss/pages/types/_t-videos.scss
@@ -672,47 +672,57 @@
                 max-height: 50vh;
             }
             .m-article-header--video.variation--video {
-                gap: 32px;
                 grid-column: 1 / span 2;
                 grid-row: 2;
-            }
-        }
-        @each $name in ('small', 'medium') {
-            @include breakpoint('#{$name}') {
-                .m-media.variation--video {
-                    grid-column: 1 / span 2;
-                    grid-row: 1;
-                }
-                .m-article-header--video.variation--video {
-                    grid-column: 1;
-                    grid-row: 2;
-                    margin-bottom: 34px !important;
-                    margin-top: 34px;
-                }
+                margin-top: 34px;
 
-                .o-playlist {
-                    max-height: 300px;
-                    margin-top: 60px;
+                .title {
+                  margin: 0;
+
+                  &::before {
+                    display: none;
+                  }
                 }
             }
-        }
-        @include breakpoint('small') {
-          grid-template-columns: 1fr 1fr;
         }
         @include breakpoint('medium') {
-          grid-template-columns: 2fr 1fr;
-        }
-        @include breakpoint('xsmall') {
-            grid-template-columns: 1fr;
+            grid-template-columns: 2fr 1fr;
 
+            .m-media.variation--video {
+                grid-column: 1 / span 2;
+                grid-row: 1;
+                margin-top: unset;
+            }
             .m-article-header--video.variation--video {
-                grid-row: 3;
+                grid-column: 1;
+                grid-row: 2;
                 margin-bottom: 34px !important;
                 margin-top: 34px;
             }
-            .o-playlist {
-                max-height: 25vh;
+            .m-media__img--embed {
+                height: 610px;
             }
+            .o-playlist {
+                top: 660px;
+                max-height: 300px;
+                max-width: 33%;
+                position: absolute;
+                right: 0;
+            }
+        }
+        @each $name in ('xsmall', 'small') {
+          @include breakpoint('#{$name}') {
+              grid-template-columns: 1fr;
+
+              .m-article-header--video.variation--video {
+                  grid-row: 3;
+                  margin-bottom: 34px !important;
+                  margin-top: 34px;
+              }
+              .o-playlist {
+                  max-height: 25vh;
+              }
+          }
         }
     }
     .o-playlist {
@@ -733,9 +743,9 @@
         }
     }
     .o-article__body {
-        @include breakpoint('medium+') {
+        @include breakpoint('small+') {
           float: left;
-          width: colspan(36, medium);
+          width: colspan(36, small);
         }
 
         @include breakpoint('large+') {


### PR DESCRIPTION
This change does the following:
- on medium screen sizes (900-1199px), allows the hanging playlist to extend down past the header, instead of pushing it down:
<img width="946" height="518" alt="Screenshot 2026-03-03 at 3 31 21 PM" src="https://github.com/user-attachments/assets/c25af3f6-0fec-4818-b807-6048d5308eac" />

- on small screen sizes (600-899px), the playlist is now stacked below the video, like the xsmall screen sizes:
<img width="869" height="624" alt="Screenshot 2026-03-03 at 3 34 09 PM" src="https://github.com/user-attachments/assets/42795557-cfc0-441d-b438-6458225b572e" />
