### PR TITLE
Set autoplay=1 in YouTube videos, to ask browsers to please play the video [WEB-3282]

### DIFF
--- a/app/Libraries/EmbedConverterService.php
+++ b/app/Libraries/EmbedConverterService.php
@@ -17,6 +17,7 @@ class EmbedConverterService
     ];
     private const YOUTUBE_DEFAULT_PARAMETERS = [
         'enablejsapi' => true,
+        'autoplay' => true,
     ];
 
     public function convertUrl($url)


### PR DESCRIPTION
[developer.chrome.com/blog/autoplay/](https://developer.chrome.com/blog/autoplay/)

It seems that EVEN IF we set `autoplay=1` on embedded videos, Chrome will decide whether to autoplay based on the individual user’s propensity to play videos on our domain, or what it calculates as the user's "Media Engagement Index” for our domain.

In our test environment, when we see the modal open up but the video doesn’t autoplay, that may be because we haven’t played videos on test in a while, but then after a while it doesn’t start autoplaying, because our “Media Engagement Index” for www-test is higher.

So: set `autoplay=1` in our youtube URLs and let the browser decide to let it play.