### PR TITLE
Remove non-public videos on import [WEB-3330]

### DIFF
--- a/app/Console/Commands/YouTubeVideosAndPlaylists.php
+++ b/app/Console/Commands/YouTubeVideosAndPlaylists.php
@@ -84,7 +84,7 @@ class YouTubeVideosAndPlaylists extends AbstractYoutubeCommand
             foreach ($sourceVideos as $source) {
                 if ($source['status']['privacyStatus'] !== 'public') {
                     // Remove private and unlisted videos
-                    Video::withoutGlobalScopes()->firstWhere('youbute_id', $source['id'])->delete();
+                    Video::withoutGlobalScopes()->firstWhere('youtube_id', $source['id'])->delete();
                     continue;
                 }
                 $thumbnail = $this->highestResolutionThumbnail($source['snippet']['thumbnails']);

--- a/app/Console/Commands/YouTubeVideosAndPlaylists.php
+++ b/app/Console/Commands/YouTubeVideosAndPlaylists.php
@@ -82,6 +82,11 @@ class YouTubeVideosAndPlaylists extends AbstractYoutubeCommand
         foreach ($sourceIds->chunk(YouTubeService::ITEMS_PER_REQUEST) as $chunkOfSourceIds) {
             $sourceVideos = $this->youtube->videosByIds($chunkOfSourceIds, $fields);
             foreach ($sourceVideos as $source) {
+                if ($source['status']['privacyStatus'] !== 'public') {
+                    // Remove private and unlisted videos
+                    Video::withoutGlobalScopes()->firstWhere('youbute_id', $source['id'])->delete();
+                    continue;
+                }
                 $thumbnail = $this->highestResolutionThumbnail($source['snippet']['thumbnails']);
                 $video = Video::withoutGlobalScopes()->firstWhere('youtube_id', $source['id'])->fill([
                     'title' => $this->normalizeTitle($source['snippet']['title']),

--- a/app/Http/Controllers/Twill/VideoController.php
+++ b/app/Http/Controllers/Twill/VideoController.php
@@ -65,6 +65,25 @@ class VideoController extends BaseController
         return $filters->merge($afterSecondFilter);
     }
 
+    protected function getDefaultQuickFilters(): QuickFilters
+    {
+        $filters = parent::getDefaultQuickFilters();
+        $withoutLast = $filters->splice(0, 4);
+        $withoutLast->add(
+            QuickFilter::make()
+                ->queryString('trash')
+                ->label(twillTrans('twill::lang.listing.filter.trash'))
+                ->onlyEnableWhen($this->getIndexOption('restore'))
+                ->amount(function () {
+                    return $this->repository->withoutGlobalScope('available')->onlyTrashed()->count();
+                })
+                ->apply(function (Builder $builder) {
+                    return $builder->withoutGlobalScope('available')->onlyTrashed();
+                })
+        );
+        return $withoutLast;
+    }
+
     protected function getIndexTableColumns(): TableColumns
     {
         $columns = parent::getIndexTableColumns();

--- a/app/Http/Controllers/Twill/VideoController.php
+++ b/app/Http/Controllers/Twill/VideoController.php
@@ -41,12 +41,6 @@ class VideoController extends BaseController
                         $builder->where('playlists.id', $playlistId);
                     });
                 }),
-            BasicFilter::make()
-                ->queryString('privacy')
-                ->options(collect(['private' => 'Private', 'public' => 'Public', 'unlisted' => 'Unlisted']))
-                ->apply(function (Builder $builder, string $privacy) {
-                    $builder->withoutGlobalScope('available')->where('privacy', $privacy);
-                }),
         ]);
     }
 
@@ -68,39 +62,7 @@ class VideoController extends BaseController
                 ->amount(fn () => $this->repository->where('is_captioned', true)->count())
                 ->apply(fn (Builder $builder) => $builder->where('is_captioned', true))
         );
-        $filters->add(
-            QuickFilter::make()
-                ->queryString('private')
-                ->label('Private')
-                ->amount(function () {
-                    return $this->repository->withoutGlobalScope('available')->where('privacy', 'private')->count();
-                })
-                ->apply(function (Builder $builder) {
-                    return $builder->withoutGlobalScope('available')->where('privacy', 'private');
-                })
-        );
-
         return $filters->merge($afterSecondFilter);
-    }
-
-
-    protected function getDefaultQuickFilters(): QuickFilters
-    {
-        $filters = parent::getDefaultQuickFilters();
-        $withoutLast = $filters->splice(0, 4);
-        $withoutLast->add(
-            QuickFilter::make()
-                ->queryString('trash')
-                ->label(twillTrans('twill::lang.listing.filter.trash'))
-                ->onlyEnableWhen($this->getIndexOption('restore'))
-                ->amount(function () {
-                    return $this->repository->withoutGlobalScope('available')->onlyTrashed()->count();
-                })
-                ->apply(function (Builder $builder) {
-                    return $builder->withoutGlobalScope('available')->onlyTrashed();
-                })
-        );
-        return $withoutLast;
     }
 
     protected function getIndexTableColumns(): TableColumns
@@ -135,12 +97,6 @@ class VideoController extends BaseController
             Text::make()
                 ->field('format')
                 ->title('Format')
-        );
-        $columns->add(
-            Text::make()
-                ->field('privacy')
-                ->title('Privacy')
-                ->customRender(fn (Video $video) => ucfirst($video->privacy))
         );
         $columns->add(
             Text::make()

--- a/app/Models/Video.php
+++ b/app/Models/Video.php
@@ -235,6 +235,13 @@ class Video extends AbstractModel
         return 'video';
     }
 
+    protected static function booted(): void
+    {
+        static::addGlobalScope('available', function (Builder $query) {
+            $query->where('privacy', '<>', 'private')->where('privacy', '<>', 'unlisted');
+        });
+    }
+
     protected function transformMappingInternal()
     {
         return [

--- a/app/Models/Video.php
+++ b/app/Models/Video.php
@@ -235,15 +235,6 @@ class Video extends AbstractModel
         return 'video';
     }
 
-    protected static function booted(): void
-    {
-        static::addGlobalScope('available', function (Builder $query) {
-            if (!App::environment('production')) {
-                $query->where('privacy', '<>', 'private');
-            }
-        });
-    }
-
     protected function transformMappingInternal()
     {
         return [


### PR DESCRIPTION
I think I must have just imagined doing this before. This change deletes private and unlisted videos on import and does away with the "available" scope.