### PR TITLE
Remove maxlength validation for list_description [WEB3324]

### DIFF
--- a/app/Http/Requests/Twill/VideoRequest.php
+++ b/app/Http/Requests/Twill/VideoRequest.php
@@ -17,7 +17,6 @@ class VideoRequest extends Request
     {
         return [
             'title' => 'required',
-            'list_description' => 'max:255'
         ];
     }
 }


### PR DESCRIPTION
Since the videos.list_description column is already a text column, we don't actually care how long it is, we just want the editors to know because it will be displayed in tight spaces.