### PR TITLE
Mititgate Axios supply-chain compromise

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "videojs-event-tracking": "^1.0.3"
   },
   "overrides": {
+    "axios": "0.30.3",
     "minimatch": "^10.2.1",
     "semver": "^7.5.2"
   },


### PR DESCRIPTION
I'm not sure if this is necessary, but better safe than sorry. By adding the last known safe version of "axios" to "overrides" we ensure a transient dependency does not install the malicious version.