### PR TITLE
Add validation rule for innerText of HTML string [WEB-3324]

### DIFF
--- a/app/Http/Requests/Twill/VideoRequest.php
+++ b/app/Http/Requests/Twill/VideoRequest.php
@@ -3,6 +3,7 @@
 namespace App\Http\Requests\Twill;
 
 use A17\Twill\Http\Requests\Admin\Request;
+use App\Rules\InnerTextLength;
 
 class VideoRequest extends Request
 {
@@ -10,6 +11,7 @@ class VideoRequest extends Request
     {
         return [
             'title' => 'required',
+            'list_description' => [new InnerTextLength(max: 255)],
         ];
     }
 
@@ -17,6 +19,7 @@ class VideoRequest extends Request
     {
         return [
             'title' => 'required',
+            'list_description' => [new InnerTextLength(max: 255)],
         ];
     }
 }

--- a/app/Rules/InnerTextLength.php
+++ b/app/Rules/InnerTextLength.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Rules;
+
+use Closure;
+use Illuminate\Contracts\Validation\ValidationRule;
+
+/**
+ * Validate the length of a string of HTML without the tags.
+ */
+class InnerTextLength implements ValidationRule
+{
+    public function __construct(
+        protected int $min = 0,
+        protected int $max = 0,
+    ) {
+    }
+
+    public function validate(string $attribute, mixed $value, Closure $fail): void
+    {
+        $innerText = strip_tags((string) $value);
+        $length = mb_strlen($innerText);
+        if ($length > $this->max) {
+            $fail("The :attribute must be less than {$this->max} characters.");
+        } elseif ($length < $this->min) {
+            $fail("The :attribute must be greater than {$this->min} characters.");
+        }
+    }
+}


### PR DESCRIPTION
This mirrors the live character count validation for WYSIWYG fields in Twill.