### PR TITLE
Address mismatched cover image aspect ratio [WEB-3340]

### DIFF
--- a/frontend/scss/molecules/_m-media.scss
+++ b/frontend/scss/molecules/_m-media.scss
@@ -249,7 +249,7 @@
     content: '';
     display: block;
     height: 0;
-    padding-bottom: math.percentage(math.div(10, 16));
+    padding-bottom: math.percentage(math.div(9, 16));
   }
 
   .m-media--m.m-media--contain .m-media__contain--spacer,


### PR DESCRIPTION
Updates this:
<img width="1728" height="1117" alt="Screenshot 2026-04-15 at 11 17 25 AM" src="https://github.com/user-attachments/assets/dbc4195e-5807-44a9-8be1-22f19fdc0be5" />
to this:
<img width="3680" height="2392" alt="Screenshot 2026-04-15 at 11 17 43 AM" src="https://github.com/user-attachments/assets/019a3bcc-786b-4b1b-9814-4a943189cba5" />
