### PR TITLE
Use the `sentry_logs` driver instead of `sentry` [WEB-3348]

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,7 +13,7 @@ KIOSK_DOMAIN='kiosk.artic.edu'
 TWILL_DEV_MODE=''
 LOG_LEVEL='debug'
 LOG_CHANNEL='stack'
-LOG_STACK='single,sentry'
+LOG_STACK='single,sentry_logs'
 
 # Needed for twill:build
 # See: https://github.com/area17/twill/issues/2329

--- a/app/Console/Commands/AbstractYoutubeCommand.php
+++ b/app/Console/Commands/AbstractYoutubeCommand.php
@@ -65,7 +65,7 @@ abstract class AbstractYoutubeCommand extends Command
 
     protected function log($message, $level = 'info')
     {
-        Log::channel('sentry')->{$level}($message);
+        Log::channel('sentry_logs')->{$level}($message);
         $this->{$level}($message, OutputInterface::VERBOSITY_DEBUG);
     }
 

--- a/app/Console/Commands/YouTubeQuota.php
+++ b/app/Console/Commands/YouTubeQuota.php
@@ -5,6 +5,7 @@ namespace App\Console\Commands;
 use App\Services\OAuth\GoogleOAuthService;
 use App\Services\YouTube\YouTubeService;
 use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Log;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class YouTubeQuota extends Command
@@ -19,7 +20,7 @@ class YouTubeQuota extends Command
         parent::__construct();
         $oAuth->setApplicationName(YouTubeService::SERVICE_NAME);
         $this->youtube = new YouTubeService($oAuth->client);
-        $this->youtube->setLogger(fn ($message) => $this->info($message, OutputInterface::VERBOSITY_DEBUG));
+        $this->youtube->setLogger($this->log(...));
     }
 
     public function handle()
@@ -35,5 +36,11 @@ class YouTubeQuota extends Command
             "YouTube service quota - remaining: $remaining, resets in: $hours $minutes ($resets)",
             OutputInterface::VERBOSITY_QUIET,
         );
+    }
+
+    protected function log($message, $level = 'info')
+    {
+        Log::channel('sentry_logs')->{$level}($message);
+        $this->{$level}($message, OutputInterface::VERBOSITY_DEBUG);
     }
 }

--- a/config/logging.php
+++ b/config/logging.php
@@ -118,8 +118,8 @@ return [
             'replace_placeholders' => true,
         ],
 
-        'sentry' => [
-            'driver' => 'sentry',
+        'sentry_logs' => [
+            'driver' => 'sentry_logs',
             'level' => env('SENTRY_LOG_LEVEL', 'info'),
         ],
 


### PR DESCRIPTION
I got some feedback from the Sentry devs regarding our logging issue:

Apparently, Sentry made two logging drivers: `sentry` and `sentry_logs`. When we originally set up Sentry in our system only `sentry` existed, so that's what we configured. It is very basic and treats a log message like a trace event. But as time moved on, Sentry created a new `sentry_logs` driver for more explicit log import and handling in their interface. And they kept the old driver around for backwards compatibility.

So, as I was setting this up, I made the naive assumption that `sentry_logs` was just an alias of `sentry` and left the website configured with the `sentry` driver. This change finally straightens all that out, using the newer `sentry_logs` driver to properly format and import our logs into Sentry's log explorer interface.

For their part, they've opened up an issue to address this confusion in their documentation: https://github.com/getsentry/sentry-laravel/issues/1131