### PR TITLE
Fix YouTube caption import

### DIFF
--- a/app/Console/Commands/AbstractYoutubeCommand.php
+++ b/app/Console/Commands/AbstractYoutubeCommand.php
@@ -51,12 +51,7 @@ abstract class AbstractYoutubeCommand extends Command
         $requestCount = $this->youtube->getRequestCount();
         $sessionUsage = $this->youtube->getSessionUsage();
         $remainingQuota = $this->youtube->getRemainingQuota(quiet: true);
-        $level = 'info';
-        if ($remainingQuota <= 0) {
-            $level = 'error';
-        } elseif ($remainingQuota < YouTubeService::QUOTA_LIMIT * .10) { // Less than 10% of the daily limit
-            $level = 'warn';
-        }
+        $level = $remainingQuota <= 0 ? 'error' : 'info';
         $this->log(
             'YouTube service session end - ' .
                 "request count: $requestCount, " .

--- a/app/Console/Commands/AbstractYoutubeCommand.php
+++ b/app/Console/Commands/AbstractYoutubeCommand.php
@@ -38,7 +38,12 @@ abstract class AbstractYoutubeCommand extends Command
         $quota = is_null($this->option('quota')) ? $this->option('quota') : (int) $this->option('quota');
         $force = is_null($this->option('force')) ? $this->option('force') : (bool) $this->option('force');
         try {
-            $this->youtube->clearSession()->session(fn () => $this->handleCommand(), $quota, $force);
+            $this->youtube->clearSession()->session(
+                fn () => $this->handleCommand(),
+                class_basename($this),
+                $quota,
+                $force,
+            );
         } catch (YouTubeServiceException $exception) {
             $code = $exception->getCode();
             $this->log($exception->getMessage(), 'error');

--- a/app/Console/Commands/YouTubeCaptions.php
+++ b/app/Console/Commands/YouTubeCaptions.php
@@ -32,6 +32,7 @@ class YouTubeCaptions extends AbstractYoutubeCommand
      */
     private function updateExistingCaptions(): void
     {
+        $videoImport = class_basename(\App\Console\Commands\YouTubeVideosAndPlaylists::class);
         $captionedVideos = Video::where('is_captioned', true)
             ->where('privacy', 'public')
             ->whereHas('captions', function (Builder $query) {
@@ -39,6 +40,7 @@ class YouTubeCaptions extends AbstractYoutubeCommand
                     $query->whereNotNull('file');
                 });
             })
+            ->where('uploaded_at', '>', $this->youtube->getLastCompletedAt($videoImport))
             ->latest('uploaded_at');
         $progress = !$this->output->isDebug() ?
             $this->output->createProgressBar($captionedVideos->count()) :

--- a/app/Http/Controllers/Twill/IntegrationController.php
+++ b/app/Http/Controllers/Twill/IntegrationController.php
@@ -13,7 +13,7 @@ class IntegrationController extends Controller
     public function show()
     {
         $integrations = [
-            'Google' => $this->getGoogleOAuthIntegration(),
+            'Google' => $this->getGoogleOAuthService(),
             'YouTube' => $this->getYouTubeService(),
         ];
 
@@ -43,7 +43,7 @@ class IntegrationController extends Controller
         return redirect()->route('twill.general.integrations.show');
     }
 
-    private function getGoogleOAuthIntegration()
+    private function getGoogleOAuthService()
     {
         $googleOAuth = app(GoogleOAuthService::class);
         $hasAccess = $googleOAuth->hasAccess();
@@ -52,13 +52,16 @@ class IntegrationController extends Controller
         }
         $isExpired = $googleOAuth->isAccessTokenExpired();
 
-        $connection = $hasAccess ? ['enabled' => !$isExpired] : null;
-        $name = class_basename(GoogleOAuthService::class);
+        $status = $hasAccess ?
+            ($isExpired ? 'yellow' : 'green') :
+            'red';
+        $updatedAt = Carbon::parse($googleOAuth->lastRefreshedAt(), 'UTC')->tz('America/Chicago');
         $message = $hasAccess ?
             ($isExpired ? 'Access token expired' : 'Access granted') :
             'Not authorized';
         $actions = array();
         if ($hasAccess) {
+            $name = class_basename(GoogleOAuthService::class);
             $actions[] = [
                 'name' => 'Revoke',
                 'url' => route('twill.general.integrations.service.action', [
@@ -89,17 +92,9 @@ class IntegrationController extends Controller
             ];
         }
 
-        $status = 'red';
-        if ($connection && $connection['enabled'] ?? false) {
-            $status = 'green';
-        } elseif ($connection) {
-            $status = 'yellow';
-        }
-
         return [
-            'connection' => $connection,
-            'name' => $name,
             'status' => $status,
+            'updated_at' => $updatedAt->toDayDateTimeString(),
             'message' => $message,
             'actions' => $actions,
         ];
@@ -108,24 +103,25 @@ class IntegrationController extends Controller
     private function getYouTubeService()
     {
         $youTubeService = app(YouTubeService::class);
+        $lastCompletedAt = Carbon::parse($youTubeService->getLastCompletedAt(), 'UTC')->tz('America/Chicago');
+        $lastFailedAt = Carbon::parse($youTubeService->getLastFailedAt(), 'UTC')->tz('America/Chicago');
+        $remainingQuota = $youTubeService->getRemainingQuota(quiet: true);
 
-        $dbLastSucceededAt = $youTubeService->getLastCompletedAt();
-        $dbLastFailedAt = $youTubeService->getLastFailedAt();
-
-        $lastSucceededAt = $dbLastSucceededAt ? Carbon::parse($dbLastSucceededAt, 'UTC') : null;
-        $lastFailedAt = $dbLastFailedAt ? Carbon::parse($dbLastFailedAt, 'UTC') : null;
-        $lastFailedReason = $youTubeService->getLastFailedReason();
-
-        $status = 'red';
-        if ($lastSucceededAt && (!$lastFailedAt || $lastSucceededAt->gt($lastFailedAt))) {
-            $status = 'green';
+        $status = $lastCompletedAt->gt($lastFailedAt) ?
+            ($remainingQuota ? 'green' : 'yellow') :
+            'red';
+        $message = '';
+        if ($lastCompletedAt->equalTo($lastFailedAt)) {
+            $message = $youTubeService->getLastFailedReason();
+        } else {
+            $message = 'Remaining quota: ' . $remainingQuota . '/' . $youTubeService::QUOTA_LIMIT;
         }
 
         return [
-            'last_succeeded_at' => $lastSucceededAt ? $lastSucceededAt->tz('America/Chicago')->toDayDateTimeString() : '',
-            'last_failed_at' => $lastFailedAt && (!$lastSucceededAt || $lastFailedAt->gt($lastSucceededAt)) ? $lastFailedAt->tz('America/Chicago')->toDayDateTimeString() : '',
-            'message' => $lastFailedAt && (!$lastSucceededAt || $lastFailedAt->gt($lastSucceededAt)) ? $lastFailedReason : '',
             'status' => $status,
+            'updated_at' => $lastCompletedAt->toDayDateTimeString(),
+            'message' => $message,
+            'actions' => [],
         ];
     }
 }

--- a/app/Http/Controllers/Twill/IntegrationController.php
+++ b/app/Http/Controllers/Twill/IntegrationController.php
@@ -109,7 +109,7 @@ class IntegrationController extends Controller
     {
         $youTubeService = app(YouTubeService::class);
 
-        $dbLastSucceededAt = $youTubeService->getLastSucceededAt();
+        $dbLastSucceededAt = $youTubeService->getLastCompletedAt();
         $dbLastFailedAt = $youTubeService->getLastFailedAt();
 
         $lastSucceededAt = $dbLastSucceededAt ? Carbon::parse($dbLastSucceededAt, 'UTC') : null;

--- a/app/Services/OAuth/GoogleOAuthService.php
+++ b/app/Services/OAuth/GoogleOAuthService.php
@@ -62,7 +62,7 @@ class GoogleOAuthService
             throw new GoogleOAuthServiceException('Error fetching access token: ' . $accessToken['error_description']);
         }
         return (bool) DB::table('oauth')->insert([
-            'created_at' => now(),
+            'created_at' => now('UTC'),
             'provider' => self::PROVIDER,
             'access_token' => json_encode($accessToken),
         ]);
@@ -174,7 +174,7 @@ class GoogleOAuthService
         $updatedAccessToken = array_merge($accessToken, $newAccessToken);
         if (
             DB::table('oauth')->where('provider', self::PROVIDER)->update([
-                'updated_at' => now(),
+                'updated_at' => now('UTC'),
                 'access_token' => $updatedAccessToken,
             ])
         ) {

--- a/app/Services/OAuth/GoogleOAuthService.php
+++ b/app/Services/OAuth/GoogleOAuthService.php
@@ -129,6 +129,14 @@ class GoogleOAuthService
     }
 
     /**
+     * Get the last time the access token was refreshed.
+     */
+    public function lastRefreshedAt(): string
+    {
+        return DB::table('oauth')->where('provider', self::PROVIDER)->pluck('updated_at')->first();
+    }
+
+    /**
      * Delete the record of the access token from the database.
      */
     public function deleteAccess(): bool

--- a/app/Services/YouTube/YouTubeService.php
+++ b/app/Services/YouTube/YouTubeService.php
@@ -6,6 +6,7 @@ use Google\Client;
 use Google\Service\Exception as GoogleServiceException;
 use Google\Service\Resource;
 use Google\Service\YouTube;
+use Illuminate\Database\Query\Builder;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\LazyCollection;
@@ -133,14 +134,14 @@ class YouTubeService
     /**
      * Run tasks in the context of a session, tracking quota usage and requests.
      */
-    public function session(\Closure $run, ?int $quota = null, bool $force = false): void
+    public function session(\Closure $run, string $command, ?int $quota = null, bool $force = false): void
     {
         if (!is_null($quota)) {
             $this->setSessionQuota($quota);
         }
         $this->setForceLimit($force);
         $start = now('UTC');
-        DB::table(self::SESSION_TABLE)->insert(['created_at' => $start]);
+        DB::table(self::SESSION_TABLE)->insert(['command' => $command, 'created_at' => $start]);
         try {
             $run();
         } catch (GoogleServiceException $exception) {
@@ -365,15 +366,20 @@ class YouTubeService
         return $response;
     }
 
-    public function getLastSucceededAt()
+    public function getLastCompletedAt(?string $command = null): ?string
     {
-        return DB::table(self::SESSION_TABLE)
-            ->whereNull('errored_at')
+        $query = DB::table(self::SESSION_TABLE);
+        if ($command) {
+            $query = $query->where('command', $command);
+        }
+
+        return $query
+            ->where(fn (Builder $query) => $query->whereNotNull('errored_at')->orWhereNotNull('updated_at'))
             ->latest()
             ->first()?->created_at;
     }
 
-    public function getLastFailedAt()
+    public function getLastFailedAt(): ?string
     {
         return DB::table(self::SESSION_TABLE)
             ->whereNotNull('errored_at')
@@ -381,7 +387,7 @@ class YouTubeService
             ->first()?->errored_at;
     }
 
-    public function getLastFailedReason()
+    public function getLastFailedReason(): ?string
     {
         return DB::table(self::SESSION_TABLE)
             ->whereNotNull('errored_at')

--- a/database/migrations/2026_06_24_095126_add_command_column_to_youtube_service_sessions_table.php
+++ b/database/migrations/2026_06_24_095126_add_command_column_to_youtube_service_sessions_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('youtube_service_sessions', function (Blueprint $table) {
+            $table->string('command')->nullable()->after('errored_at');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('youtube_service_sessions', function (Blueprint $table) {
+            $table->dropColumn('command');
+        });
+    }
+};

--- a/resources/views/twill/integrations/show.blade.php
+++ b/resources/views/twill/integrations/show.blade.php
@@ -4,7 +4,7 @@
     <table id="integrations">
         <thead>
             <tr>
-                <th>Status</th><th>Service</th><th>Last succeeded</th><th>Last failed</th><th>Message</th><th>Actions</th>
+                <th>Status</th><th>Service</th><th>Updated</th><th>Message</th><th>Actions</th>
             </tr>
         </thead>
         <tbody>
@@ -17,10 +17,7 @@
                         {{ $name }}
                     </td>
                     <td>
-                        {{ $integration['last_succeeded_at'] ?? '' }}
-                    </td>
-                    <td>
-                        {{ $integration['last_failed_at'] ?? '' }}
+                        {{ $integration['updated_at'] ?? '' }}
                     </td>
                     <td>
                         {{ $integration['message'] ?? '' }}


### PR DESCRIPTION
The new code I added to check for updated captions recently was just burning thru our daily quota in a matter of hours. This adds a `command` column to the `youtube_service_sessions` table to record which command was run for that session. Then, in the `youtube:captions` command, only the videos that have been updated since the last `youtube:import` command was run are checked for caption updates. This should drastically reduce how many quota points the new caption update check uses.