### PR TITLE
Fix Youtube GTM race condition [Gen-AI, Claude-Sonnet-4.6] [WEB-3377]

### DIFF
--- a/frontend/js/app.js
+++ b/frontend/js/app.js
@@ -118,10 +118,6 @@ document.addEventListener('DOMContentLoaded', function(){
   });
 });
 
-window.onYouTubeIframeAPIReady = function() {
-  AIC.YouTubeonYouTubeIframeAPIReady = true;
-}
-
 // Make console.log safe
 if (typeof console === 'undefined') {
   window.console = {

--- a/frontend/js/functions/core/youtubeEmbed.js
+++ b/frontend/js/functions/core/youtubeEmbed.js
@@ -1,5 +1,33 @@
 import { triggerCustomEvent } from '@area17/a17-helpers';
 
+// Load the YouTube IFrame API once, as soon as this module runs (page load),
+// rather than waiting for the first embed to be created. An embed's iframe
+// starts loading its own content the moment it's inserted into the DOM, and
+// broadcasts a "ready" handshake to whichever code is listening for it at
+// that moment. If the IFrame API is still loading when that happens (because
+// it was only requested on-demand), the handshake is missed and that
+// player's event listeners (onReady/onStateChange) never attach. Giving the
+// API a head start at page load avoids that race for every embed, including
+// the first one created in a fresh document.
+function _loadYouTubeIframeApi() {
+  return new Promise((resolve) => {
+    if (window.YT && window.YT.Player) {
+      resolve();
+      return;
+    }
+    window.onYouTubeIframeAPIReady = resolve;
+    if (!document.getElementById('youtubeapijs')) {
+      const youtubeScript = document.createElement('script');
+      youtubeScript.src = 'https://www.youtube.com/iframe_api';
+      youtubeScript.id = 'youtubeapijs';
+      const firstScript = document.getElementsByTagName('script')[0];
+      firstScript.parentNode.insertBefore(youtubeScript, firstScript);
+    }
+  });
+}
+
+const youtubeApiReady = _loadYouTubeIframeApi();
+
 const youtubeEmbed = function(iframe) {
   if (!(iframe instanceof Element)) {
     iframe = document.getElementById(iframe);
@@ -35,7 +63,7 @@ const youtubeEmbed = function(iframe) {
       'gtm.videoTitle': player.getVideoData().title,
       'gtm.videoUrl': player.getVideoUrl(),
       'gtm.videoDuration': player.getDuration(),
-      'gtm.videoCurrentTime': currentTime,
+      'gtm.videoCurrentTime': player.getCurrentTime(),
       'gtm.videoPercent': _playedPercent(player),
       'gtm.videoVisible': true,
     });
@@ -129,11 +157,8 @@ const youtubeEmbed = function(iframe) {
   }
 
   function _initYoutubePlayer(iframeId) {
-    console.log('trying in _initYoutubePlayer');
-    if (AIC.YouTubeonYouTubeIframeAPIReady) {
-      if (!(iframeId in AIC.YouTubeembeds)) {
-        console.log('building the player in _initYoutubePlayer');
-        const player = new YT.Player(iframeId, {
+    if (iframeId in AIC.YouTubeembeds) return;
+    new YT.Player(iframeId, {
           playerVars: {
             'autoplay': 1,
             'enablejsapi': 1,
@@ -144,40 +169,12 @@ const youtubeEmbed = function(iframe) {
             'onStateChange': _onStateChange,
           },
         });
-        // If the onReady event doesn't get called on its own, check the element manually
-        // and call `onReady` once it's available.
-        const onReadyPollInterval = setInterval(() => {
-          console.log(' ', player.getPlayerState !== undefined);
-          if (player.getPlayerState !== undefined) {
-            clearInterval(onReadyPollInterval);
-            if (!(iframeId in AIC.YouTubeembeds)) {
-              console.log('calling onReady in _initYoutubePlayer');
-              _onReady({ target: player });
-            }
-          }
-        }, 50);
-        // After 5 solid seconds of trying, stop.
-        setTimeout(() => {
-          clearInterval(onReadyPollInterval);
-        }, 5000);
-      }
-    } else {
-      setTimeout(() => _initYoutubePlayer(iframeId), 10);
-    }
   };
-
-  if (!document.getElementById('youtubeapijs')) {
-    const youtubeScript = document.createElement('script');
-    youtubeScript.src = 'https://www.youtube.com/iframe_api';
-    youtubeScript.id = 'youtubeapijs';
-    const firstScript = document.getElementsByTagName('script')[0];
-    firstScript.parentNode.insertBefore(youtubeScript, firstScript);
-  }
 
   if (!iframe.id) {
     iframe.id = `youtube_${Math.random().toString(36).substring(2, 9)}`;
   }
-  _initYoutubePlayer(iframe.id);
+  youtubeApiReady.then(() => _initYoutubePlayer(iframe.id));
 };
 
 function controlYouTubePlayer(player, commands) {

--- a/frontend/js/functions/core/youtubeEmbed.js
+++ b/frontend/js/functions/core/youtubeEmbed.js
@@ -40,6 +40,7 @@ const youtubeEmbed = function(iframe) {
   };
 
   let youtubePlayerTimer;
+  let currentVideoId = null;
 
   function onPlayerEnded(player) {
     triggerCustomEvent(document, 'gtm:push', {
@@ -55,8 +56,18 @@ const youtubeEmbed = function(iframe) {
   }
 
   function onPlayerPlaying(player) {
-    const currentTime = player.getCurrentTime();
-    const status = currentTime < 1 ? 'start' : 'resume';
+    const videoId = player.getVideoData().video_id;
+    const status = videoId !== currentVideoId ? 'start' : 'resume';
+    if (status === 'start') {
+      // A new video is playing (as opposed to a resume after pause/buffer).
+      // Track it and reset the played-percent checks so progress is tracked
+      // for this video instead of carrying over thresholds already hit by a
+      // previous video in the same player (e.g. advancing between shorts).
+      currentVideoId = videoId;
+      for (const playedCheck in playedChecks) {
+        playedChecks[playedCheck] = false;
+      }
+    }
     triggerCustomEvent(document, 'gtm:push', {
       'event': 'gtm.video',
       'gtm.videoStatus': status,

--- a/resources/views/partials/_head-js.blade.php
+++ b/resources/views/partials/_head-js.blade.php
@@ -2,6 +2,5 @@
 
 <script>
     var AIC = window.AIC || {};
-    AIC.YouTubeonYouTubeIframeAPIReady = false;
     AIC.YouTubeembeds = {};
 </script>


### PR DESCRIPTION
`youtubeEmbed.js` only requested the YouTube iframe API script the first time an embed was created—e.g., on-demand when the modal opened. On a fresh document, that script has to load from scratch, while the modal's iframe starts loading its own content at the same instant. The iframe's embedded player broadcasts a one-time "ready" handshake the moment its content finishes loading; if the API (and thus YT.Player) isn't constructed yet to receive it, the handshake is missed permanently for that player, no YouTube events fired including our GTM calls. 

With this PR, the iframe API script now loads once, eagerly, at module-evaluation time (page load) behind a single promise (`youtubeApiReady`), instead of being requested lazily on first embed.

`_initYoutubePlayer` is gated on that promise for every call, removing the old boolean-flag/10ms-poll mechanism and the unreliable `getPlayerState !== undefined` backup-poll hack. The first player is now wired identically to later ones.

Additionally, `onPlayerPlaying` now classifies `start` vs `resume` by comparing the player's current `video_id` against the last-tracked one, instead of `getCurrentTime() < 1`, which didn't accurately classify the action that took place.

Also, the 25/50/75% `playedChecks` flags now reset whenever a new video starts, fixing a real bug where watching one short past 75% silently suppressed progress tracking for every subsequent short in that same modal session (since the player/closure persists across `loadVideoById` calls).