### PR TITLE
Set new native-trim setting to "true" for all font objects [WEB-3431]

### DIFF
--- a/frontend/scss/setup/_typography.scss
+++ b/frontend/scss/setup/_typography.scss
@@ -40,7 +40,7 @@ f-display-3
 $f-display-3: generate-font-obj((font-family: $serif-font,
     font-family-loaded: $serif-font--loaded,
     font-loaded-class: $serif-font-loaded-class,
-    native-trim: false,
+    native-trim: true,
     settings: ('xsmall': (font-size: 31, line-height: 36, text-transform: uppercase, letter-spacing: .1em, push: 0),
       'small+': (font-size: 51, line-height: 60, push: -2),
       'medium+': (font-size: 58, line-height: 68, push: -1),
@@ -73,7 +73,7 @@ f-display-2
 $f-display-2: generate-font-obj((font-family: $sans-serif-font,
     font-family-loaded: $sans-serif-font--loaded,
     font-loaded-class: $sans-serif-font-loaded-class,
-    native-trim: false,
+    native-trim: true,
     settings: ('xsmall': (font-size: 31, line-height: 36, font-weight: 300, text-transform: uppercase, letter-spacing: 0.08em, push: 0),
       'small+': (font-size: 51, line-height: 60, push: 0),
       'medium+': (font-size: 58, line-height: 68, push: 0),
@@ -106,7 +106,7 @@ f-display-1
 $f-display-1: generate-font-obj((font-family: $sans-serif-font,
     font-family-loaded: $sans-serif-font--loaded,
     font-loaded-class: $sans-serif-font-loaded-class,
-    native-trim: false,
+    native-trim: true,
     settings: ('xsmall': (font-size: 26, line-height: 32, font-weight: 300, text-transform: uppercase, letter-spacing: 0.08em, push: 0),
       'small+': (font-size: 32, line-height: 40, push: 0),
       'medium+': (font-size: 36, line-height: 44, push: 0))));
@@ -138,7 +138,7 @@ f-headline
 $f-headline: generate-font-obj((font-family: $sans-serif-font,
     font-family-loaded: $sans-serif-font--loaded,
     font-loaded-class: $sans-serif-font-loaded-class,
-    native-trim: false,
+    native-trim: true,
     settings: ('xsmall': (font-size: 28, line-height: 32, font-weight: 300, letter-spacing: 0.01em, push: 0),
       'small+': (font-size: 35, line-height: 40),
       'medium+': (font-size: 38, line-height: 44))));
@@ -170,7 +170,7 @@ f-headline-lightbox
 $f-headline-lightbox: generate-font-obj((font-family: $sans-serif-font,
     font-family-loaded: $sans-serif-font--loaded,
     font-loaded-class: $sans-serif-font-loaded-class,
-    native-trim: false,
+    native-trim: true,
     settings: ('xsmall': (font-size: 20, line-height: 28, letter-spacing: -0.005em, push: -1),
       'small+': (font-size: 22, line-height: 30, push: 0),
       'medium+': (font-size: 26, line-height: 34, push: 0))));
@@ -202,7 +202,7 @@ f-headline-editorial
 $f-headline-editorial: generate-font-obj((font-family: $serif-font,
     font-family-loaded: $serif-font--loaded,
     font-loaded-class: $serif-font-loaded-class,
-    native-trim: false,
+    native-trim: true,
     settings: ('xsmall': (font-size: 28, line-height: 32, letter-spacing: -0.01em, push: 0),
       'small+': (font-size: 35, line-height: 40, push: 0),
       'medium+': (font-size: 38, line-height: 44, push: 0))));
@@ -233,7 +233,7 @@ f-deck
 $f-deck: generate-font-obj((font-family: $serif-font,
     font-family-loaded: $serif-font--loaded,
     font-loaded-class: $serif-font-loaded-class,
-    native-trim: false,
+    native-trim: true,
     settings: ('xsmall': (font-size: 22, line-height: 28, letter-spacing: -0.005em, push: -1),
       'small+': (font-size: 24, line-height: 32, push: 0),
       'medium+': (font-size: 28, line-height: 36, push: 0))));
@@ -283,7 +283,7 @@ f-module-title-2 (f-subheading-2)
 $f-module-title-2: generate-font-obj((font-family: $sans-serif-font,
     font-family-loaded: $sans-serif-font--loaded,
     font-loaded-class: $sans-serif-font-loaded-class,
-    native-trim: false,
+    native-trim: true,
     settings: ('xsmall': (font-size: 17, line-height: 24, letter-spacing: .09em, text-transform: uppercase, font-weight: normal, push: 0),
       'small+': (font-size: 20, line-height: 28, push: 0),
       'medium+': (font-size: 21, line-height: 28, push: 0))));
@@ -317,7 +317,7 @@ module-title-1
 $f-module-title-1: generate-font-obj((font-family: $sans-serif-font,
     font-family-loaded: $sans-serif-font--loaded,
     font-loaded-class: $sans-serif-font-loaded-class,
-    native-trim: false,
+    native-trim: true,
     settings: ('xsmall': (font-size: 16, line-height: 24, letter-spacing: 0.01em, push: 1),
       'small+': (font-size: 17, line-height: 24, push: 0))));
 
@@ -348,7 +348,7 @@ f-subheading-1 (f-subheading-1-editorial)
 $f-subheading-1: generate-font-obj((font-family: $sans-serif-font,
     font-family-loaded: $sans-serif-font--loaded,
     font-loaded-class: $sans-serif-font-loaded-class,
-    native-trim: false,
+    native-trim: true,
     settings: ('xsmall': (font-size: 17, line-height: 24, letter-spacing: 0.01em, push: 0),
       'small+': (font-size: 18, line-height: 28, push: 0),
       'xlarge': (font-size: 19, line-height: 28, push: 1))));
@@ -382,7 +382,7 @@ f-subheading-3
 $f-subheading-3: generate-font-obj((font-family: $sans-serif-font,
     font-family-loaded: $sans-serif-font--loaded,
     font-loaded-class: $sans-serif-font-loaded-class,
-    native-trim: false,
+    native-trim: true,
     settings: ('xsmall': (font-size: 19, line-height: 26, letter-spacing: 0.01em, push: 0),
       'medium+': (font-size: 21, line-height: 30, push: 0),
       'xlarge': (font-size: 24, line-height: 34, push: 0))));
@@ -415,7 +415,7 @@ f-subheading-4
 $f-module-title-4: generate-font-obj((font-family: $sans-serif-font,
     font-family-loaded: $sans-serif-font--loaded,
     font-loaded-class: $sans-serif-font-loaded-class,
-    native-trim: false,
+    native-trim: true,
     settings: ('xsmall': (font-size: 16, line-height: 24, font-weight: 500, letter-spacing: 0.01em, push: 1),
       'small+': (font-size: 18, line-height: 28, font-weight: 500, push: 0),
       'xlarge': (font-size: 19, line-height: 28, font-weight: 500, push: 1))));
@@ -448,7 +448,7 @@ f-body
 $f-body: generate-font-obj((font-family: $sans-serif-font,
     font-family-loaded: $sans-serif-font--loaded,
     font-loaded-class: $sans-serif-font-loaded-class,
-    native-trim: false,
+    native-trim: true,
     settings: ('xsmall': (font-size: 16, line-height: 24, font-weight: 300, letter-spacing: 0.01em, push: 1),
       'small+': (font-size: 18, line-height: 28, push: 0),
       'xlarge': (font-size: 19, line-height: 28, push: 1))));
@@ -479,7 +479,7 @@ f-body-emphasis
 $f-body-emphasis: generate-font-obj((font-family: $sans-serif-font,
     font-family-loaded: $sans-serif-font--loaded,
     font-loaded-class: $sans-serif-font-loaded-class,
-    native-trim: false,
+    native-trim: true,
     settings: ('xsmall': (font-size: 16, line-height: 24, font-weight: 300, font-style: italic, letter-spacing: .01em, push: 1),
       'small+': (font-size: 18, line-height: 28, push: 0),
       'xlarge': (font-size: 19, line-height: 28, push: 1))));
@@ -538,7 +538,7 @@ f-body-editorial
 $f-body-editorial: generate-font-obj((font-family: $serif-font,
     font-family-loaded: $serif-font--loaded,
     font-loaded-class: $serif-font-loaded-class,
-    native-trim: false,
+    native-trim: true,
     settings: ('xsmall': (font-size: 17, line-height: 24, letter-spacing: 0.005em, font-weight: 500, push: -1),
       'small+': (font-size: 18, line-height: 28, letter-spacing: 0, push: -2),
       'large+': (font-size: 19, line-height: 28, push: -2))));
@@ -565,7 +565,7 @@ f-body-editorial-emphasis
 $f-body-editorial-emphasis: generate-font-obj((font-family: $serif-font,
     font-family-loaded: $serif-font--loaded,
     font-loaded-class: $serif-font-loaded-class,
-    native-trim: false,
+    native-trim: true,
     settings: ('xsmall': (font-size: 17, line-height: 24, font-style: italic, letter-spacing: .005em, push: -1),
       'small+': (font-size: 18, line-height: 28, letter-spacing: 0, push: -2),
       'large+': (font-size: 19, line-height: 28, push: -2))));
@@ -620,7 +620,7 @@ f-body-editorial-reference
 $f-body-editorial-reference: generate-font-obj((font-family: $sans-serif-font,
     font-family-loaded: $sans-serif-font--loaded,
     font-loaded-class: $sans-serif-font-loaded-class,
-    native-trim: false,
+    native-trim: true,
     settings: ('xsmall': (font-size: 17, line-height: 24, letter-spacing: 0.01em, font-weight: 300, push: 0),
       'small+': (font-size: 18, line-height: 28, letter-spacing: 0, push: 0),
       'xlarge': (font-size: 19, line-height: 28, push: 1))));
@@ -667,7 +667,7 @@ f-buttons
 $f-buttons: generate-font-obj((font-family: $sans-serif-font,
     font-family-loaded: $sans-serif-font--loaded,
     font-loaded-class: $sans-serif-font-loaded-class,
-    native-trim: false,
+    native-trim: true,
     settings: ('xsmall': (font-size: 16, line-height: 24, letter-spacing: 0.01em, push: 1),
       'medium+': (font-size: 17, line-height: 24, push: 0))));
 
@@ -697,7 +697,7 @@ f-secondary
 $f-secondary: generate-font-obj((font-family: $sans-serif-font,
     font-family-loaded: $sans-serif-font--loaded,
     font-loaded-class: $sans-serif-font-loaded-class,
-    native-trim: false,
+    native-trim: true,
     settings: ('xsmall': (font-size: 16, line-height: 24, font-weight: 300, letter-spacing: 0.01em, push: 1),
       'medium+': (font-size: 17, line-height: 28, push: 0))));
 
@@ -757,7 +757,7 @@ f-tertiary
 $f-tertiary: generate-font-obj((font-family: $sans-serif-font,
     font-family-loaded: $sans-serif-font--loaded,
     font-loaded-class: $sans-serif-font-loaded-class,
-    native-trim: false,
+    native-trim: true,
     settings: ('xsmall': (font-size: 14, line-height: 20, font-weight: 300, letter-spacing: 0.01em, push: 0),
       'small+': (font-size: 16, line-height: 24, push: 1),
       'medium+': (font-size: 17, line-height: 28, push: 0))));
@@ -862,7 +862,7 @@ f-tag
 $f-tag: generate-font-obj((font-family: $sans-serif-font,
     font-family-loaded: $sans-serif-font--loaded,
     font-loaded-class: $sans-serif-font-loaded-class,
-    native-trim: false,
+    native-trim: true,
     settings: ('xsmall': (font-size: 11, line-height: 16, letter-spacing: .14em, text-transform: uppercase, push: 0),
       'medium+': (font-size: 12, line-height: 16, push: 0))));
 
@@ -893,7 +893,7 @@ f-caption-title
 $f-caption-title: generate-font-obj((font-family: $sans-serif-font,
     font-family-loaded: $sans-serif-font--loaded,
     font-loaded-class: $sans-serif-font-loaded-class,
-    native-trim: false,
+    native-trim: true,
     settings: ('xsmall': (font-size: 15, line-height: 20, letter-spacing: 0.01em, push: 0))));
 
 @mixin f-caption-title() {
@@ -923,7 +923,7 @@ f-caption
 $f-caption: generate-font-obj((font-family: $sans-serif-font,
     font-family-loaded: $sans-serif-font--loaded,
     font-loaded-class: $sans-serif-font-loaded-class,
-    native-trim: false,
+    native-trim: true,
     settings: ('xsmall': (font-size: 15, line-height: 20, font-weight: 300, letter-spacing: 0.01em, push: 0))));
 
 @mixin f-caption() {
@@ -952,7 +952,7 @@ f-list-7
 $f-list-7: generate-font-obj((font-family: $serif-font,
     font-family-loaded: $serif-font--loaded,
     font-loaded-class: $serif-font-loaded-class,
-    native-trim: false,
+    native-trim: true,
     settings: ('xsmall': (font-size: 14, line-height: 20, push: 0),
       'small+': (font-size: 20, line-height: 28, push: -2))));
 
@@ -986,7 +986,7 @@ f-list-6
 $f-list-6: generate-font-obj((font-family: $serif-font,
     font-family-loaded: $serif-font--loaded,
     font-loaded-class: $serif-font-loaded-class,
-    native-trim: false,
+    native-trim: true,
     settings: ('xsmall': (font-size: 24, line-height: 28, push: -1))));
 
 @mixin f-list-6() {
@@ -1015,7 +1015,7 @@ f-list-5
 $f-list-5: generate-font-obj((font-family: $serif-font,
     font-family-loaded: $serif-font--loaded,
     font-loaded-class: $serif-font-loaded-class,
-    native-trim: false,
+    native-trim: true,
     settings: ('xsmall': (font-size: 22, line-height: 28, letter-spacing: -0.005em, push: -1),
       'medium+': (font-size: 24, line-height: 32, push: -2),
       'large+': (font-size: 31, line-height: 40, letter-spacing: -0.01em, push: 0),
@@ -1047,7 +1047,7 @@ f-list-4
 $f-list-4: generate-font-obj((font-family: $serif-font,
     font-family-loaded: $serif-font--loaded,
     font-loaded-class: $serif-font-loaded-class,
-    native-trim: false,
+    native-trim: true,
     settings: ('xsmall': (font-size: 22, line-height: 28, letter-spacing: -0.005em, push: -1),
       'medium+': (font-size: 24, line-height: 32, push: -2),
       'large+': (font-size: 28, line-height: 36, push: 0),
@@ -1079,7 +1079,7 @@ f-list-3
 $f-list-3: generate-font-obj((font-family: $serif-font,
     font-family-loaded: $serif-font--loaded,
     font-loaded-class: $serif-font-loaded-class,
-    native-trim: false,
+    native-trim: true,
     settings: ('xsmall': (font-size: 22, line-height: 28, letter-spacing: -0.005em, push: -1),
       'xlarge': (font-size: 24, line-height: 32, push: -2))));
 
@@ -1109,7 +1109,7 @@ f-list-2
 $f-list-2: generate-font-obj((font-family: $serif-font,
     font-family-loaded: $serif-font--loaded,
     font-loaded-class: $serif-font-loaded-class,
-    native-trim: false,
+    native-trim: true,
     settings: ('xsmall': (font-size: 19, line-height: 24, push: -2),
       'small+': (font-size: 22, line-height: 28, letter-spacing: -0.005em, push: -1))));
 
@@ -1139,7 +1139,7 @@ f-list-1
 $f-list-1: generate-font-obj((font-family: $serif-font,
     font-family-loaded: $serif-font--loaded,
     font-loaded-class: $serif-font-loaded-class,
-    native-trim: false,
+    native-trim: true,
     settings: ('xsmall': (font-size: 20, line-height: 28, push: -2))));
 
 @mixin f-list-1() {
@@ -1169,7 +1169,7 @@ f-list-1--dense
 $f-list-1--dense: generate-font-obj((font-family: $serif-font,
     font-family-loaded: $serif-font--loaded,
     font-loaded-class: $serif-font-loaded-class,
-    native-trim: false,
+    native-trim: true,
     settings: ('xsmall': (font-size: 16, line-height: 20, push: -2),
       'small': (font-size: 19, line-height: 24, push: -2),
       'medium+': (font-size: 20, line-height: 28, push: -2))));
@@ -1201,7 +1201,7 @@ f-quote
 $f-quote: generate-font-obj((font-family: $serif-font,
     font-family-loaded: $serif-font--loaded,
     font-loaded-class: $serif-font-loaded-class,
-    native-trim: false,
+    native-trim: true,
     settings: ('xsmall': (font-size: 24, line-height: 32, letter-spacing: -0.015em, font-style: italic, push: -2),
       'small+': (font-size: 27, line-height: 36, push: -1),
       'medium+': (font-size: 30, line-height: 40, push: -1))));
@@ -1252,7 +1252,7 @@ f-dropcap-editorial
 $f-dropcap-editorial: generate-font-obj((font-family: $serif-font,
     font-family-loaded: $serif-font--loaded,
     font-loaded-class: $serif-font-loaded-class,
-    native-trim: false,
+    native-trim: true,
     settings: ('xsmall': (font-size: 54, line-height: 60, text-transform: uppercase, push: 1),
       'medium+': (font-size: 100, line-height: 120, push: -1))));
 
@@ -1283,7 +1283,7 @@ f-numeral-date
 $f-numeral-date: generate-font-obj((font-family: $serif-font,
     font-family-loaded: $serif-font--loaded,
     font-loaded-class: $serif-font-loaded-class,
-    native-trim: false,
+    native-trim: true,
     settings: ('xsmall': (font-size: 38, line-height: 44, letter-spacing: -0.04em, push: 0),
       'small+': (font-size: 44, line-height: 56, push: 1),
       'large+': (font-size: 46, line-height: 60, push: 1))));
@@ -1314,7 +1314,7 @@ f-main-nav
 $f-main-nav: generate-font-obj((font-family: $sans-serif-font,
     font-family-loaded: $sans-serif-font--loaded,
     font-loaded-class: $sans-serif-font-loaded-class,
-    native-trim: false,
+    native-trim: true,
     settings: ('xsmall': (font-size: 16, line-height: 24, font-weight: 300, letter-spacing: 0.01em, push: 1),
       'small+': (font-size: 18, line-height: 24, letter-spacing: 0.015em, push: 0),
       'medium+': (font-size: 19, line-height: 28, push: 1))));
@@ -1371,7 +1371,7 @@ f-small-caps
 $f-small-caps: generate-font-obj((font-family: $sans-serif-font,
     font-family-loaded: $sans-serif-font--loaded,
     font-loaded-class: $sans-serif-font-loaded-class,
-    native-trim: false,
+    native-trim: true,
     settings: ('xsmall': (font-size: 11, line-height: 48, letter-spacing: .14em, text-transform: uppercase, push: 0),
       'medium+': (font-size: 12, line-height: 48, push: 0))));
 


### PR DESCRIPTION
There does not seem to be any visual changes. As a visual example, on the left is all fonts with `$native-trim` set to `false`, and on the right is with `$native-trim` set to `true`:
<img width="1920" height="1080" alt="Screenshot 2026-07-30 at 4 41 59 PM" src="https://github.com/user-attachments/assets/19867491-12d1-4afd-84d9-6b2414b2e68f" />

In the styles tab of the developer panel, we can see that `text-box-edge` and `text-box-trim` are applied to elements with these classes:
<img width="360" height="282" alt="Screenshot 2026-07-30 at 4 46 36 PM" src="https://github.com/user-attachments/assets/941072e2-5cb0-4678-b5f7-43f421477cb1" />

Please confirm for yourself at http://www-dev.artic.edu/styles-verification.
