### PR TITLE
Silence webpack warnings in dev environment

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -52,6 +52,7 @@ module.exports = async () => {
 
   return {
     mode: isProd ? 'production' : 'development',
+    stats: (isProd || isCI) ? 'normal' : 'errors-only',
     entry: {
       app: ['./frontend/scss/app.scss', './frontend/js/app.js'],
       blocks3D: ['./frontend/js/blocks3D.js'],


### PR DESCRIPTION
This is probably temporary, but it is hard to debug style issues with so many Sass deprecation warnings clogging up my console output. We can remove this when style token work is done.