### PR TITLE
Check that generic page id is an int before trying to cast it

### DIFF
--- a/app/Http/Controllers/GenericPagesController.php
+++ b/app/Http/Controllers/GenericPagesController.php
@@ -83,6 +83,10 @@ class GenericPagesController extends FrontController
         $page = $this->genericPageRepository->forSlug($idSlug);
 
         if (empty($page)) {
+            if (!is_int($idSlug)) {
+                abort(404);
+            }
+
             $page = $this->genericPageRepository->getById((int) $idSlug);
 
             if (!$page) {


### PR DESCRIPTION
This page addresses anomalous requests we've been seeing in Sentry that cause DB errors, for example:
https://art-institute-of-chicago.sentry.io/issues/7288886304/events/10d3886867654a1aa118ea4b9266567f/?project=1249128