### PR TITLE
Create middleware that checks file extensions

### DIFF
--- a/app/Http/Middleware/CheckFileExtension.php
+++ b/app/Http/Middleware/CheckFileExtension.php
@@ -19,7 +19,7 @@ class CheckFileExtension
         $allExtensions = array_unique(array_merge($mediaExtensions, $fileExtensions));
 
         $filename = array_last($request->segments());
-        $extension = File::extension($filename);
+        $extension = strtolower(File::extension($filename));
         if ($extension && !in_array($extension, $allExtensions)) {
             abort(404);
         }

--- a/app/Http/Middleware/CheckFileExtension.php
+++ b/app/Http/Middleware/CheckFileExtension.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\File;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * If the request is for a file with a file type we do not serve, throw a 404.
+ */
+class CheckFileExtension
+{
+    public function handle(Request $request, Closure $next): Response
+    {
+        $mediaExtensions = config('twill.media_library.allowed_extensions');
+        $fileExtensions = config('twill.file_library.allowed_extensions');
+        $allExtensions = array_unique(array_merge($mediaExtensions, $fileExtensions));
+
+        $filename = array_last($request->segments());
+        $extension = File::extension($filename);
+        if ($extension && !in_array($extension, $allExtensions)) {
+            abort(404);
+        }
+
+        return $next($request);
+    }
+}

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -58,6 +58,7 @@ return Application::configure(basePath: dirname(__DIR__))
         $middleware->web(append: [
             \App\Http\Middleware\RedirectVanityPaths::class,
             \App\Http\Middleware\SanitizeQueryParameters::class,
+            \App\Http\Middleware\CheckFileExtension::class,
         ]);
     })
     ->withExceptions(function (Exceptions $exceptions) {

--- a/config/twill.php
+++ b/config/twill.php
@@ -398,7 +398,7 @@ return [
         'image_service' => env('MEDIA_LIBRARY_IMAGE_SERVICE', 'A17\Twill\Services\MediaLibrary\Imgix'),
         'acl' => env('MEDIA_LIBRARY_ACL', 'private'),
         'filesize_limit' => env('MEDIA_LIBRARY_FILESIZE_LIMIT', 50),
-        'allowed_extensions' => ['svg', 'jpg', 'gif', 'png', 'jpeg', 'mp4', 'glb', 'gltf'],
+        'allowed_extensions' => ['gif', 'jpeg', 'jpg', 'mp4', 'png', 'svg'],
         'init_alt_text_from_filename' => false,
         'prefix_uuid_with_local_path' => config('twill.file_library.prefix_uuid_with_local_path', false),
         'translated_form_fields' => false,
@@ -418,5 +418,12 @@ return [
                 ],
             ],
         ],
-    ]
+    ],
+
+    'file_library' => [
+        'allowed_extensions' => [
+            '3mf', 'docx', 'fbx', 'glb', 'jpg', 'json', 'mov', 'mp3', 'mp4',
+            'obj', 'otf', 'pdf', 'png', 'tif', 'txt', 'usdz', 'xml', 'zip',
+        ],
+    ],
 ];


### PR DESCRIPTION
If a request is for a file of a type we don't serve, throw a 404 error.