### PR TITLE
Remove unused DigitalPublicationRepository::getWelcomeNote()

### DIFF
--- a/app/Http/Controllers/DigitalPublicationsController.php
+++ b/app/Http/Controllers/DigitalPublicationsController.php
@@ -82,7 +82,6 @@ class DigitalPublicationsController extends BaseScopedController
             'borderlessHeader' => false,
             'unstickyHeader' => true,
             'canonicalUrl' => $canonicalPath,
-            'welcomeNote' => $this->repository->getWelcomeNote($item),
             'showAll' => $showAll,
         ]);
     }

--- a/app/Repositories/DigitalPublicationRepository.php
+++ b/app/Repositories/DigitalPublicationRepository.php
@@ -52,15 +52,4 @@ class DigitalPublicationRepository extends ModuleRepository
             'showAll' => false,
         ];
     }
-
-    public function getWelcomeNote($item): DigitalPublicationArticle
-    {
-        $welcomeNotes = $item->getRelated('welcome_note_section');
-
-        if (!config('aic.is_preview_mode')) {
-            $welcomeNotes = $welcomeNotes->where('published', true);
-        }
-
-        return $welcomeNotes->first();
-    }
 }


### PR DESCRIPTION
`welcome_note_display` is used directly in the templates, and `getWelcomeNote()` does not appear to be used anymore. Remove it because it throws an error if the `welcome_note_display` is not set. 