### PR TITLE
Refresh CSRF token with JS [Gen-AI, Claude-Sonnet-5] [WEB-3454]

### DIFF
--- a/app/Http/Controllers/FrontController.php
+++ b/app/Http/Controllers/FrontController.php
@@ -182,6 +182,8 @@ class FrontController extends BaseController
                 return $this->getRelatedSidebarItemsData();
             case 'loadExhibitionImages':
                 return $this->loadExhibitionImages();
+            case 'csrfToken':
+                return response()->json(['token' => csrf_token()]);
             default:
                 return response()->json(['error' => 'Invalid request'], 400);
         }

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -60,6 +60,17 @@ return Application::configure(basePath: dirname(__DIR__))
             \App\Http\Middleware\SanitizeQueryParameters::class,
             \App\Http\Middleware\CheckFileExtension::class,
         ]);
+
+        // Not applied to any group automatically — routes opt in via
+        // ->withoutMiddleware('sessionless') to skip session/server-side CSRF handling
+        // (and the Set-Cookie headers that come with it) so their responses
+        // can be edge-cached. Only safe for routes/views that never read or
+        // write session state.
+        $middleware->group('sessionless', [
+            \Illuminate\Session\Middleware\StartSession::class,
+            \Illuminate\Foundation\Http\Middleware\PreventRequestForgery::class,
+            \Illuminate\View\Middleware\ShareErrorsFromSession::class,
+        ]);
     })
     ->withExceptions(function (Exceptions $exceptions) {
         // Sentrty error reporting

--- a/frontend/js/app.js
+++ b/frontend/js/app.js
@@ -1,6 +1,6 @@
 import { manageBehaviors, resized, getCurrentMediaQuery, forEach, lazyLoad } from '@area17/a17-helpers';
 import * as Behaviors from './behaviors/core';
-import { lockBody, focusTrap, focusDisplayHandler, ajaxPageLoad, ajaxPageLoadMaskToggle, historyProxy, loadProgressBar, setScrollDirection, anchorLinksScroll, headerAwareScroll, fontObservers, modals, collectionFilters, googleTagManager, accessibleContent, headerHeight, roadblock } from './functions/core';
+import { lockBody, focusTrap, focusDisplayHandler, ajaxPageLoad, ajaxPageLoadMaskToggle, historyProxy, loadProgressBar, setScrollDirection, anchorLinksScroll, headerAwareScroll, fontObservers, modals, collectionFilters, googleTagManager, accessibleContent, headerHeight, roadblock, refreshCsrfToken } from './functions/core';
 /**
  * A17
  * @see Doc: https://code.area17.com/a17/fe-boilerplate/wikis/js-app
@@ -28,6 +28,10 @@ A17.ajaxLinksFailSafe = (A17.env === 'production') ? true : false;
 
 // Expose A17 so it's visible to kiosk
 window.A17 = A17;
+
+// Re-establish a session/CSRF token if this page was served from CDN cache
+// without one (see routes/web.php's home route)
+refreshCsrfToken();
 
 document.addEventListener('DOMContentLoaded', function(){
   if (A17.print) {

--- a/frontend/js/functions/core/index.js
+++ b/frontend/js/functions/core/index.js
@@ -27,4 +27,5 @@ export { default as ajaxRequestCustom } from './ajaxRequestCustom';
 export { default as roadblock } from './roadblock';
 export { default as getOffsetTop } from './getOffsetTop';
 export { default as cookieHandler } from './cookieHandler';
+export { default as refreshCsrfToken } from './refreshCsrfToken';
 export { default as shortsPlayer } from './shortsPlayer';

--- a/frontend/js/functions/core/refreshCsrfToken.js
+++ b/frontend/js/functions/core/refreshCsrfToken.js
@@ -12,10 +12,10 @@ const refreshCsrfToken = function() {
   ajaxRequest({
     url: '/ajaxData?q=csrfToken',
     type: 'GET',
-    onSuccess: function(data) {
+    onSuccess(data) {
       try {
         data = JSON.parse(data);
-        var meta = document.querySelector('meta[name="csrf-token"]');
+        const meta = document.querySelector('meta[name="csrf-token"]');
         if (meta && data.token) {
           meta.setAttribute('content', data.token);
         }

--- a/frontend/js/functions/core/refreshCsrfToken.js
+++ b/frontend/js/functions/core/refreshCsrfToken.js
@@ -1,0 +1,29 @@
+import { ajaxRequest } from '@area17/a17-helpers';
+
+// The homepage is served from Cloudflare's edge cache without a Set-Cookie
+// header, so a visitor landing on `/` may have no session/XSRF-TOKEN cookie
+// yet, and the csrf-token meta tag baked into that cached HTML is stale.
+// Fetch a live token to establish a session and refresh the meta tag.
+const refreshCsrfToken = function() {
+  if (document.cookie.indexOf('XSRF-TOKEN=') !== -1) {
+    return;
+  }
+
+  ajaxRequest({
+    url: '/ajaxData?q=csrfToken',
+    type: 'GET',
+    onSuccess: function(data) {
+      try {
+        data = JSON.parse(data);
+        var meta = document.querySelector('meta[name="csrf-token"]');
+        if (meta && data.token) {
+          meta.setAttribute('content', data.token);
+        }
+      } catch (err) {
+        console.error('Error refreshing CSRF token', err);
+      }
+    }
+  });
+};
+
+export default refreshCsrfToken;

--- a/resources/views/components/molecules/_m-aside-newsletter.blade.php
+++ b/resources/views/components/molecules/_m-aside-newsletter.blade.php
@@ -7,7 +7,6 @@
         <div class="m-aside-newsletter__field__wrapper">
             <span class="m-aside-newsletter__field">
                 <label for="email{{ $rand }}" class="f-secondary">Email address</label>
-                @csrf
                 <input type="email" name="email" id="email{{ $rand }}" class="f-secondary" placeholder="{{ $placeholder ?? 'your@email.com' }}" autocomplete="email">
                 <button type="submit" class="{{ $btnFont ?? 'f-buttons' }} m-aside-newsletter__btn--submit" data-gtm-event-category="subscribe" data-gtm-event="email">Subscribe</button>
             </span>

--- a/routes/web.php
+++ b/routes/web.php
@@ -66,8 +66,12 @@ Route::group([
 });
 
 // Landing Page
+// Excludes the 'sessionless' middleware group (see bootstrap/app.php) so no
+// Set-Cookie header is sent. The CSRF token embedded in the shared layout is
+// refreshed client-side (see refreshCsrfToken.js).
 Route::get('/', [LandingPagesController::class, 'slugHome'])
     ->middleware('cache.headers:public;max_age=120')
+    ->withoutMiddleware('sessionless')
     ->name('home');
 Route::group([
     'middleware' => [SanitizeQueryParameters::class],


### PR DESCRIPTION
In order for the signup form to work on each page, and for each page to be cached in the CDN, this PR refreshes the CSRF token that's presented in the <meta> tag via JS, so that server pages don't have to present the token directly.