### PR TITLE
Convert start date to Carbon Datetime [Sentry]

### DIFF
--- a/app/Models/Event.php
+++ b/app/Models/Event.php
@@ -475,7 +475,7 @@ class Event extends AbstractModel
         $query->rightJoin('event_metas', function ($join) {
             $join->on('events.id', '=', 'event_metas.event_id');
         });
-        $query->where('event_metas.date', '>=', $startDate);
+        $query->where('event_metas.date', '>=', Carbon::parse($startDate));
 
         if ($endDate) {
             $query->where('event_metas.date_end', '<=', Carbon::parse($endDate)->endOfDay());


### PR DESCRIPTION
This change prevents this class of DB error:
https://art-institute-of-chicago.sentry.io/issues/7313079779/events/4656040e36b3481b85710ecccf2e6dfe/?project=1249128&referrer=event-or-group-header