### PR TITLE
Prevent invalid video requests from hitting the DB [Sentry]

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -239,16 +239,28 @@ Route::group([
     Route::get('/videos/archive', [VideoController::class, 'index'])->name('videos.archive');
     Route::redirect('/videos/archives', '/videos/archive');
 });
-Route::get('/videos/shorts', [ShortsController::class, 'index'])->name('shorts.index');
-Route::get('/videos/shorts/{video}', [ShortsController::class, 'show'])->name('shorts.show');
-Route::get('/videos/shorts/{video}/previous', [ShortsController::class, 'previous'])->name('shorts.previous');
-Route::get('/videos/shorts/{video}/next', [ShortsController::class, 'next'])->name('shorts.next');
-Route::get('/videos/{video}/{slug?}', [VideoController::class, 'show'])->name('videos.show');
-Route::get('/playlists/{playlist}', [PlaylistController::class, 'show'])->name('playlists.show');
-Route::get(
-    '/playlists/{playlist}/videos/{video}/{slug?}',
-    [PlaylistVideoController::class, 'show'],
-)->scopeBindings()->name('playlists.videos.show');
+Route::get('/videos/shorts', [ShortsController::class, 'index'])
+    ->name('shorts.index');
+Route::get('/videos/shorts/{video}', [ShortsController::class, 'show'])
+    ->whereNumber('video')
+    ->name('shorts.show');
+Route::get('/videos/shorts/{video}/previous', [ShortsController::class, 'previous'])
+    ->whereNumber('video')
+    ->name('shorts.previous');
+Route::get('/videos/shorts/{video}/next', [ShortsController::class, 'next'])
+    ->whereNumber('video')
+    ->name('shorts.next');
+Route::get('/videos/{video}/{slug?}', [VideoController::class, 'show'])
+    ->whereNumber('video')
+    ->name('videos.show');
+Route::get('/playlists/{playlist}', [PlaylistController::class, 'show'])
+    ->whereNumber('playlist')
+    ->name('playlists.show');
+Route::get('/playlists/{playlist}/videos/{video}/{slug?}', [PlaylistVideoController::class, 'show'])
+    ->whereNumber('playlist')
+    ->whereNumber('video')
+    ->scopeBindings()
+    ->name('playlists.videos.show');
 
 // Mirador kiosk routes
 Route::get('mirador', function () {


### PR DESCRIPTION
This change adds the `whereNumber()` constraint to video routes to prevent this class of DB error (likely caused by AI bots):
https://art-institute-of-chicago.sentry.io/issues/7411683792/events/aac12e6127bb46b5aeddeaa108112fcd/?referrer=event-or-group-header