### PR TITLE
Change DigiPub rules for update to ignore HTML

### DIFF
--- a/app/Http/Requests/Twill/DigitalPublicationRequest.php
+++ b/app/Http/Requests/Twill/DigitalPublicationRequest.php
@@ -17,8 +17,8 @@ class DigitalPublicationRequest extends Request
     {
         return [
             'title' => 'required',
-            'listing_description' => 'max:300',
-            'hero_caption' => 'max:255',
+            'listing_description' => [new InnerTextLength(max: 300)],
+            'hero_caption' => [new InnerTextLength(max: 255)],
             'bgcolor' => 'nullable|regex:/^#[0-9a-fA-F]{6}/'
         ];
     }

--- a/app/Http/Requests/Twill/DigitalPublicationRequest.php
+++ b/app/Http/Requests/Twill/DigitalPublicationRequest.php
@@ -3,6 +3,7 @@
 namespace App\Http\Requests\Twill;
 
 use A17\Twill\Http\Requests\Admin\Request;
+use App\Rules\InnerTextLength;
 
 class DigitalPublicationRequest extends Request
 {


### PR DESCRIPTION
This change uses the fields' innertext to calculate the max characters, while ignoring html tags..